### PR TITLE
Port codebase to Python 3 syntax (modernize legacy Python 2 constructs)

### DIFF
--- a/iDiffIR/IntronModel.py
+++ b/iDiffIR/IntronModel.py
@@ -54,7 +54,7 @@ class IntronModel(object):
         self.exonsI = [(s-self.minpos, e-self.minpos) for s,e in exonsI]
     
     def __cmp__(self, other):
-        print other.gid
+        print(other.gid)
         return cmp(self.gid, other.gid)
 
     def __eq__(self, other):
@@ -430,7 +430,7 @@ def makeModels( geneModel, outdir, verbose=False, graphDirs=None, graphDirsOnly=
                   List of reduced models
 
         """
-        for i in xrange(len(pModels)):             
+        for i in range(len(pModels)):             
             indicator.update()
 
     # run parallel
@@ -443,14 +443,14 @@ def makeModels( geneModel, outdir, verbose=False, graphDirs=None, graphDirsOnly=
             task_queue.put( clusterTuple )
             nTasks += 1
 
-        for _ in xrange(procs):
+        for _ in range(procs):
             Process(target=procCluster,
                     args=(task_queue, status_queue)).start()
 
-        for _ in xrange(procs):
+        for _ in range(procs):
             task_queue.put('STOP')
 
-        for _ in xrange(nTasks):
+        for _ in range(nTasks):
             processedModels = status_queue.get()
             models.extend(processedModels)
             updateIndicator(processedModels)

--- a/iDiffIR/SpliceGrapher/formats/FastaLoader.py
+++ b/iDiffIR/SpliceGrapher/formats/FastaLoader.py
@@ -79,7 +79,7 @@ class FastaLoader(object) :
         if self.verbose : sys.stderr.write('Found %d FASTA records in %s\n' % (len(self.sequences), fastaPath))
 
     def keys(self) :
-        return self.sequences.keys()
+        return list(self.sequences.keys())
 
     def __len__(self) :
         return len(self.sequences)
@@ -96,18 +96,18 @@ class FastaLoader(object) :
         i = 0
         while i < len(ref) :
             last = min(i+width, len(ref))
-            print "%10d: %s" % (i+offset, ref[i:last])
+            print("%10d: %s" % (i+offset, ref[i:last]))
             if showMatches :
                 midstr = "%12s" % ' '
-                for j in xrange(i,last) :
+                for j in range(i,last) :
                     if ref[j] == est[j] :
                         midstr += "|"
                     else  :
                         midstr += " "
-                print midstr
+                print(midstr)
 
-            print "%8d: %s" % (i+offset, est[i:last])
-            print ""
+            print("%8d: %s" % (i+offset, est[i:last]))
+            print("")
             i += width
 
     def headerToSequenceID(self, header) :
@@ -166,7 +166,7 @@ class FastaLoader(object) :
         """
         Writes a multi-line representation of the given sequence to stdout.
         """
-        print self.sequenceString(seq, offset=offset, width=width)
+        print(self.sequenceString(seq, offset=offset, width=width))
 
     def subsequence(self, sequenceID, start, end, reverse=False) :
         """

--- a/iDiffIR/SpliceGrapher/formats/GTFLoader.py
+++ b/iDiffIR/SpliceGrapher/formats/GTFLoader.py
@@ -171,7 +171,7 @@ class GTFLoader(object) :
             indicator.update()
             try :
                 rec   = GTF_Line(line.strip())
-            except ValueError, ve :
+            except ValueError as ve :
                 raise ValueError('line %d: invalid GTF record:\n%s%s' % (indicator.ctr, line, str(ve)))
 
             ftype = rec.parts[FEATURE_INDEX].lower()

--- a/iDiffIR/SpliceGrapher/formats/bed.py
+++ b/iDiffIR/SpliceGrapher/formats/bed.py
@@ -96,7 +96,7 @@ class BEDRecord(object) :
         for col in ALL_COLUMNS :
             try :
                 self.attrs[col] = parts[col]
-            except IndexError, ie :
+            except IndexError as ie :
                 if col in REQUIRED_COLUMNS :
                     raise ie
                 self.attrs[col] = None

--- a/iDiffIR/SpliceGrapher/formats/fasta.py
+++ b/iDiffIR/SpliceGrapher/formats/fasta.py
@@ -109,8 +109,8 @@ class fasta_itr (object) :
     def __iter__(self) :
         return self
 
-    def next(self) :
-        return self.__itr.next()
+    def __next__(self) :
+        return next(self.__itr)
 
     def __getitem__(self,name) :
         return fasta_get_by_name(iter(self),name)
@@ -135,7 +135,7 @@ class fasta_slice (object) :
         elif type(first) == type('') :
             self.__current = None
         else :
-            raise ValueError, 'bad first'
+            raise ValueError('bad first')
 
         self.__foundFirst = False
         if self.__first == 0 or self.__first == '' :
@@ -144,7 +144,7 @@ class fasta_slice (object) :
     def __iter__(self) :
         return self
 
-    def next(self) :
+    def __next__(self) :
         """
         Implementation of the iterator interface.
         """
@@ -161,9 +161,9 @@ class fasta_slice (object) :
                         break
                     self.__current = rec.header
             if not self.__foundFirst :
-                raise ValueError, 'did not find first record'
+                raise ValueError('did not find first record')
             return rec
-        rec = self.__itr.next()
+        rec = next(self.__itr)
 
         if self.__last is not None :
             if type(self.__first) == int :
@@ -236,7 +236,7 @@ class FastaRandomizer(object) :
     """
     def __init__(self, fastaFile) :
         self.records  = [rec for rec in fasta_itr(fastaFile)]
-        self.recRange = range(len(self.records))
+        self.recRange = list(range(len(self.records)))
 
     def randomRecords(self, n) :
         """

--- a/iDiffIR/SpliceGrapher/formats/sam.py
+++ b/iDiffIR/SpliceGrapher/formats/sam.py
@@ -20,7 +20,7 @@ Module for manipulating SAM-formatted files.
 """
 from SpliceGrapher.shared.utils import ProgressIndicator, ezopen, getAttribute
 from SpliceGrapher.shared.ShortRead import *
-from sys import maxint as MAXINT
+from sys import maxsize as MAXINT
 import sys,re
 
 # Header tags
@@ -55,7 +55,7 @@ HEADER_SQ_LINE = '@SQ'
 # B -- Integer or numeric array
 VALID_VTYPES = ['A', 'i', 'f', 'Z', 'H', 'B']
 
-ALL_COLUMNS      = [QNAME, FLAG, RNAME, POS, MAPQ, CIGAR, MRNM, MPOS, ISIZE, SEQ, QUAL, TAGS] = range(12)
+ALL_COLUMNS      = [QNAME, FLAG, RNAME, POS, MAPQ, CIGAR, MRNM, MPOS, ISIZE, SEQ, QUAL, TAGS] = list(range(12))
 REQUIRED_COLUMNS = ALL_COLUMNS[:-1]
 INT_COLUMNS      = [FLAG, POS, MPOS, MAPQ]
 
@@ -150,7 +150,7 @@ def acceptSAMRecord(s, counter, **args) :
 
     try :
         rec = SAMRecord(s)
-    except ValueError, ve :
+    except ValueError as ve :
         sys.stderr.write('\n*** Error in SAM file at line %d ***\n' % counter)
         sys.stderr.write('Line: %s\n' % s)
         raise ve
@@ -167,7 +167,7 @@ def acceptSAMRecord(s, counter, **args) :
         # Convert S,H,I and D tokens into M or N:
         try :
             newCigar = convertCigarString(tokens, len(rec.attrs[SEQ]))
-        except ValueError, ve :
+        except ValueError as ve :
             raise ve
         rec.attrs[CIGAR] = newCigar
         tokens = cigarTokens(newCigar)
@@ -225,7 +225,7 @@ def convertCigarString(tokens, requiredSize) :
         try :
             # Tokens must be an integer followed by a single character
             size = int(curr[:-1])
-        except ValueError,ve :
+        except ValueError as ve :
             raise ValueError('Unrecognized CIGAR string: "%s"' % s)
 
         if symbol == 'M' :
@@ -297,7 +297,7 @@ def pysamChromosomeMap(pysamFile) :
     result = {}
     if HEADER_SQ_TAG in pysamFile.header :
         chromList = pysamFile.header[HEADER_SQ_TAG]
-        for i in xrange(len(chromList)) :
+        for i in range(len(chromList)) :
             result[str(i)] = chromList[i][HEADER_SN_TAG]
     return result
 
@@ -381,7 +381,7 @@ def pysamReadDepths(bamFile, chromosome, gene, **args) :
                 if tok[0] == BAM_CMATCH :
                     start = max(pos, loBound) - loBound
                     end   = min(upBound, pos+tok[1]) - loBound
-                    for i in xrange(start, end) :
+                    for i in range(start, end) :
                         result[i] += 1
                 pos += tok[1]
         else : # ungapped alignment
@@ -389,7 +389,7 @@ def pysamReadDepths(bamFile, chromosome, gene, **args) :
             nUngapped += 1
             start = max(r.pos+1, loBound) - loBound
             end   = min(r.pos+r.qlen+1, upBound) - loBound
-            for i in xrange(start, end+1) :
+            for i in range(start, end+1) :
                 result[i] += 1
 
     if verbose : sys.stderr.write('Loaded %d ungapped and %d spliced reads for %s\n' % (nUngapped, nSpliced, gene.id))
@@ -440,7 +440,7 @@ def pysamSpliceJunctions(pysamRecord, chrMap) :
     k      = 0
     chrom  = chrMap[str(pysamRecord.tid)]
     strand = pysamStrand(pysamRecord,tagDict)
-    for i in xrange(0,len(pos),2) :
+    for i in range(0,len(pos),2) :
         jct = SpliceJunction(chrom, pos[i], pos[i+1]+1, [exons[k],exons[k+1]], jctCode, strand)
         result.append(jct)
         k  += 1
@@ -510,7 +510,7 @@ def getSamAlignments(samRecords, **args) :
             try :
                 code   = m[-1]
                 delta  = int(m[:-1])
-            except Exception, e :
+            except Exception as e :
                 sys.stderr.write('\n*** Error in SAM file at line %d ***\n' % indicator.ctr)
                 sys.stderr.write('Line: %s\n' % line)
                 raise e
@@ -572,7 +572,7 @@ def getSamDepths(samRecords, **args) :
             try :
                 code   = m[-1]
                 delta  = int(m[:-1])
-            except Exception, e :
+            except Exception as e :
                 sys.stderr.write('\n*** Error in SAM file at line %d ***\n' % indicator.ctr)
                 sys.stderr.write('Line: %s\n' % line)
                 raise e
@@ -584,7 +584,7 @@ def getSamDepths(samRecords, **args) :
 
             # Update depth for matches only
             if code == 'M' :
-                for i in xrange(prvPos, curPos) :
+                for i in range(prvPos, curPos) :
                     depths[c][i] += 1
             prvPos = curPos
 
@@ -764,7 +764,7 @@ def getSamReadData(samRecords, **args) :
             try :
                 code   = m[-1]
                 delta  = int(m[:-1])
-            except Exception, e :
+            except Exception as e :
                 sys.stderr.write('\n*** Error in SAM file: invalid CIGAR string (column 5) at line %d ***\n' % indicator.ctr)
                 sys.stderr.write('Invalid record: %s\n' % line)
                 sys.stderr.write('CIGAR string:   %s\n' % rec.cigar())
@@ -778,7 +778,7 @@ def getSamReadData(samRecords, **args) :
 
             # Update depth for matches only
             if code == 'M' :
-                for i in xrange(prvPos, curPos) :
+                for i in range(prvPos, curPos) :
                     depths[c][i] += 1
                 if alignments :
                     align[c].append((prvPos,delta))
@@ -890,7 +890,7 @@ def recordToSpliceJunction(samRec, matches) :
     result = []
     exons  = [int(m[:-1]) for m in matches if m[-1]=='M']
     k      = 0
-    for i in xrange(0,len(pos),2) :
+    for i in range(0,len(pos),2) :
         jct = SpliceJunction(samRec.chromosome(), pos[i], pos[i+1]+1, [exons[k],exons[k+1]], jctCode, samRec.attrs[STRAND_TAG])
         result.append(jct)
         k  += 1
@@ -938,7 +938,7 @@ class SAMRecord(object) :
                 else :
                     self.attrs[col]  = parts[col]
                     self.vtypes[col] = 'A'
-            except IndexError, ie :
+            except IndexError as ie :
                 raise ValueError('Too few columns (%d<%d) in input record:\n%s' % (len(parts), len(REQUIRED_COLUMNS), s))
             col += 1
 

--- a/iDiffIR/SpliceGrapher/formats/wig.py
+++ b/iDiffIR/SpliceGrapher/formats/wig.py
@@ -77,7 +77,7 @@ class WIGRecord(object) :
         for col in ALL_COLUMNS :
             try :
                 self.attrs[col] = parts[col]
-            except IndexError, ie :
+            except IndexError as ie :
                 raise ie
 
     def chromosome(self) :

--- a/iDiffIR/SpliceGrapher/plot/PlotterConfig.py
+++ b/iDiffIR/SpliceGrapher/plot/PlotterConfig.py
@@ -20,7 +20,7 @@ Module that encapsulates a configuration for a meta-plotter.
 """
 from SpliceGrapher.shared.utils import getAttribute
 from SpliceGrapher.shared.adjust import MIN_INTRON_SIZE
-from ConfigParser import ConfigParser
+from configparser import ConfigParser
 import re, os
 
 ENV_MATCH = re.compile('\${\w\w*}')
@@ -252,7 +252,7 @@ class SinglePlotConfig(object) :
                 return parseEnvironmentVars(value)
             else : # STRING_TAGS
                 return value
-        except ValueError, ve :
+        except ValueError as ve :
             raise ValueError('Invalid assignment in config file: %s is %s, should be %s\n' % (tag, value, TAG_TYPE[tag]))
 
     def instantiate(self) :

--- a/iDiffIR/SpliceGrapher/scripts/ests_to_splicegraph.py
+++ b/iDiffIR/SpliceGrapher/scripts/ests_to_splicegraph.py
@@ -132,7 +132,7 @@ for chrom in pslDict :
             outPath   = os.path.join(opts.dir, '%s%s.gff' % (gene.id,opts.suffix))
             graph.writeGFF(outPath, haltOnError=True)
             counts[gene.strand] += 1
-        except ValueError, ve :
+        except ValueError as ve :
             if len(graph.nodeDict) == 0 :
                 if opts.singles :
                     sys.stderr.write('Unable to create graph for %s: created 0 nodes from %d PSL records.\n' % (gene.id, len(pslRecs)))

--- a/iDiffIR/SpliceGrapher/scripts/find_splice_forms.py
+++ b/iDiffIR/SpliceGrapher/scripts/find_splice_forms.py
@@ -110,7 +110,7 @@ else :
                     graph  = geneModelToSpliceGraph(gene, useCDS=useCDS)
                 except KeyError :
                     continue
-            except ValueError, ve :
+            except ValueError as ve :
                 sys.stderr.write('Cannot build graph for gene %s: %s\n' % (gene.name, str(ve)))
                 continue
 

--- a/iDiffIR/SpliceGrapher/scripts/generate_putative_sequences.py
+++ b/iDiffIR/SpliceGrapher/scripts/generate_putative_sequences.py
@@ -158,14 +158,14 @@ unresolved = 0
 for f in fileList :
     indicator.update()
     graph         = getFirstGraph(f)
-    hasUnresolved = hasUnresolvedNodes(graph.nodeDict.values())
+    hasUnresolved = hasUnresolvedNodes(list(graph.nodeDict.values()))
     if not (opts.allgenes or hasUnresolved) : continue
 
     if hasUnresolved :
         # update parent/child relationships for
         # unresolved nodes and "pretend" they are predicted
         unresolved += 1
-        nodes = graph.nodeDict.values()
+        nodes = list(graph.nodeDict.values())
         for n in nodes :
             if not n.isUnresolved() : continue
 
@@ -216,7 +216,7 @@ for c in chromList :
         indicator.update()
         graph   = graphs[c][gid]
         reverse = (graph.strand == '-')
-        nodes   = graph.nodeDict.values()
+        nodes   = list(graph.nodeDict.values())
         chrom   = graph.chromosome
 
         # Grab the DNA sequence for every distinct exon
@@ -232,14 +232,14 @@ for c in chromList :
         try :
             paths = getAllPaths(graph, limit=opts.seqlimit)
             paths.sort()
-        except ValueError, ve :
+        except ValueError as ve :
             tooLong += 1
             continue
 
         isoDict    = graph.isoformDict()
         isoStrings = {}
         # Map node strings back to isoform name
-        for k in isoDict.keys() :
+        for k in list(isoDict.keys()) :
             nodes = isoDict[k]
             key   = nodeString(nodes)
             isoStrings[key] = k

--- a/iDiffIR/SpliceGrapher/scripts/generate_splice_site_data.py
+++ b/iDiffIR/SpliceGrapher/scripts/generate_splice_site_data.py
@@ -31,18 +31,18 @@ from SpliceGrapher.SpliceGraph         import *
 
 from optparse import OptionParser, OptionGroup
 from glob     import glob
-from sys      import maxint as MAXINT
+from sys      import maxsize as MAXINT
 import os, random, sys, warnings
 
 def trainingFilter(g) :
     """Filter for accepting/rejecting training examples."""
-    for k in TRAIN_ACCEPT.keys() :
+    for k in list(TRAIN_ACCEPT.keys()) :
         if k not in g.attributes : return False
         target = TRAIN_REJECT[k].lower()
         value  = g.attributes[k].lower()
         if value.find(target) < 0 : return False
 
-    for k in TRAIN_REJECT.keys() :
+    for k in list(TRAIN_REJECT.keys()) :
         if k not in g.attributes : continue
         target = TRAIN_REJECT[k].lower()
         value  = g.attributes[k].lower()
@@ -104,13 +104,13 @@ def writeReport(options, jctDict) :
 
     # Second part of report: splice junction frequency
     totalJct = 0
-    for d in jctDict.keys() :
-        for a in jctDict[d].keys() :
+    for d in list(jctDict.keys()) :
+        for a in list(jctDict[d].keys()) :
             totalJct += jctDict[d][a]
 
     jctRecs = []
-    for d in jctDict.keys() :
-        for a in jctDict[d].keys() :
+    for d in list(jctDict.keys()) :
+        for a in list(jctDict[d].keys()) :
             pct = (100.0*jctDict[d][a])/totalJct
             jctRecs.append((d, a, jctDict[d][a], pct))
 
@@ -203,7 +203,7 @@ if opts.model :
     geneModel = loadGeneModels(opts.model, verbose=opts.verbose)
     genes     = geneModel.getAllGenes(trainingFilter)
     for g in genes :
-        if g.chromosome.lower() not in fastaDB.keys() :
+        if g.chromosome.lower() not in list(fastaDB.keys()) :
             if opts.verbose and g.chromosome.lower() not in badChrom :
                 sys.stderr.write('Ignoring gene %s: chromosome %s not in FASTA reference\n' % (g.id, g.chromosome))
                 badChrom.add(g.chromosome.lower())
@@ -230,12 +230,12 @@ if opts.splicegraphs :
         indicator.update()
         try :
             graph = getFirstGraph(f.strip())
-        except ValueError, ve :
+        except ValueError as ve :
             sys.stderr.write('Warning: %s\n' % ve)
             continue
         if graph.isEmpty() : continue
 
-        if graph.chromosome.lower() not in fastaDB.keys() :
+        if graph.chromosome.lower() not in list(fastaDB.keys()) :
             if opts.verbose and graph.chromosome.lower() not in badChrom :
                 sys.stderr.write('Ignoring gene %s: chromosome %s not in FASTA reference\n' % (graph.getName(), graph.chromosome))
                 badChrom.add(graph.chromosome.lower())
@@ -265,7 +265,7 @@ if opts.verbose : sys.stderr.write('Generating %s examples of %s sequences for %
 
 # Iterator is just the graph list for positive examples,
 # or a random iterator over negative examples
-graphIter = RandomListIterator(graphDict.keys()) if opts.negative else graphDict.keys()
+graphIter = RandomListIterator(list(graphDict.keys())) if opts.negative else list(graphDict.keys())
 
 seqCtr    = 0
 geneCount = 0

--- a/iDiffIR/SpliceGrapher/scripts/gtf2gff.py
+++ b/iDiffIR/SpliceGrapher/scripts/gtf2gff.py
@@ -19,7 +19,7 @@
 from SpliceGrapher.shared.utils import *
 from SpliceGrapher.formats.gtf  import *
 from optparse                   import OptionParser
-from sys import maxint as MAXINT
+from sys import maxsize as MAXINT
 import os,sys,gzip
 
 USAGE = """%prog GTF-file [options]
@@ -39,9 +39,9 @@ parser.add_option('--show-types', dest='showtypes', default=False, help='Outputs
 opts, args = parser.parse_args(sys.argv[1:])
 
 if opts.showtypes :
-    print "Known ENSEMBL source types:"
+    print("Known ENSEMBL source types:")
     for t in ALL_ENSEMBL_SOURCES :
-        print "  ", t
+        print("  ", t)
     sys.exit(0)
 
 if len(args) != 1 :
@@ -88,25 +88,25 @@ indicator.finish()
 # Sort records by chromosome before writing them to GFF3 file
 keys = sorted(chromDict.keys())
 if opts.verbose :
-    print "Stored information for %d chromosomes:" % len(keys)
+    print("Stored information for %d chromosomes:" % len(keys))
     if skipped :
-        print "  skipped the following record types:"
+        print("  skipped the following record types:")
         for k in sorted(skipped.keys()) :
-            print "   %s (%s records)" % (k, commaFormat(skipped[k]))
+            print("   %s (%s records)" % (k, commaFormat(skipped[k])))
 
 for k in keys :
     # Search chromosome for invalid genes
     invalid = False
-    for g in chromDict[k].keys() :
+    for g in list(chromDict[k].keys()) :
         if not chromDict[k][g].valid :
             invalid = True
             break
 
     if opts.verbose : 
         if invalid :
-            print "  chromosome %s: %12d genes (%d invalid **)" % (k, len(chromDict[k]), invalid)
+            print("  chromosome %s: %12d genes (%d invalid **)" % (k, len(chromDict[k]), invalid))
         else :
-            print "  chromosome %s: %12d genes" % (k, len(chromDict[k]))
+            print("  chromosome %s: %12d genes" % (k, len(chromDict[k])))
 
     # Write out entire chromosome
     chromDict[k].writeGFF3(outStream)

--- a/iDiffIR/SpliceGrapher/scripts/sam_filter.py
+++ b/iDiffIR/SpliceGrapher/scripts/sam_filter.py
@@ -112,7 +112,7 @@ def validSpliceSite(chrom, strand, pos, classifiers, storedValues, **args) :
         ## storedValues[chrom][strand][pos] = NOMINAL_POSITIVE
         storedValues[chrom][strand][pos] = 0.0
 
-    for svm in classifiers.values() :
+    for svm in list(classifiers.values()) :
         # The intron/exon size both depend on which classifier is used;
         # unless there are more than 2 classifiers for a site type,
         # this approach is faster in the long run than getting the
@@ -281,7 +281,7 @@ for line in samIterator(samFile, isBam=bamFormat) :
 
     try :
         rec, matches = acceptSAMRecord(s, indicator.ctr)
-    except ValueError,ve :
+    except ValueError as ve :
         invalidCigar += 1
         continue
 
@@ -374,13 +374,13 @@ indicator.finish()
 if opts.report :
     if opts.verbose : sys.stderr.write('Writing classifier scores to %s\n' % opts.report)
     quintuples = []
-    for c in donSites.keys() :
-        for s in donSites[c].keys() :
-            for p in donSites[c][s].keys() :
+    for c in list(donSites.keys()) :
+        for s in list(donSites[c].keys()) :
+            for p in list(donSites[c][s].keys()) :
                 quintuples.append((c,s,p,'d',donSites[c][s][p]))
-    for c in accSites.keys() :
-        for s in accSites[c].keys() :
-            for p in accSites[c][s].keys() :
+    for c in list(accSites.keys()) :
+        for s in list(accSites[c].keys()) :
+            for p in list(accSites[c][s].keys()) :
                 quintuples.append((c,s,p,'a',accSites[c][s][p]))
     quintuples.sort(cmp=cmpQuintuple)
     rstream = open(opts.report,'w')

--- a/iDiffIR/SpliceGrapher/setup.py
+++ b/iDiffIR/SpliceGrapher/setup.py
@@ -11,9 +11,9 @@ PYML_REQUIRED       = '0.7.7'
 #functions for showing errors and warnings (lifted from the pytables setup script)
 def _print_admonition(kind, head, body):
     tw = textwrap.TextWrapper(initial_indent='   ', subsequent_indent='   ')
-    print ".. %s:: %s" % (kind.upper(), head)
+    print(".. %s:: %s" % (kind.upper(), head))
     for line in tw.wrap(body):
-        print line
+        print(line)
 
 def print_warning(head, body=''):
     _print_admonition('warning', head, body)

--- a/iDiffIR/SpliceGrapher/shared/SpliceGraphPath.py
+++ b/iDiffIR/SpliceGrapher/shared/SpliceGraphPath.py
@@ -76,7 +76,7 @@ def getAllPaths(G, **args) :
     limit   = getAttribute('limit', None, **args)
 
     roots = set([r for r in G.getRoots() if not r.isUnresolved()])
-    for n in G.nodeDict.values() :
+    for n in list(G.nodeDict.values()) :
         for p in n.parents :
             if p.isRoot() : roots.add(p)
 
@@ -84,9 +84,9 @@ def getAllPaths(G, **args) :
     # Memoization improves efficiency
     memo  = {}
     paths = []
-    if verbose : print "Traversing %d roots in %s:" % (len(roots), G.getName())
+    if verbose : print("Traversing %d roots in %s:" % (len(roots), G.getName()))
     for r in roots  :
-        if verbose : print "  ", str(r)
+        if verbose : print("  ", str(r))
         newpaths = getPaths(r, memo, **args)
         paths.extend(newpaths)
         if limit and len(paths) > limit :
@@ -116,12 +116,12 @@ def getPaths(node, memo, **args) :
 def getLongestPath(G, verbose=False) :
     """Returns the longest path through the graph, given as a list of node pointers."""
     roots = set([r for r in G.getRoots() if not r.isUnresolved()])
-    for n in G.nodeDict.values() :
+    for n in list(G.nodeDict.values()) :
         for p in n.parents :
             if p.isRoot() : roots.add(p)
     memo   = {}
     result = None
-    if verbose : print "getLongestPath traversing %d roots in %s:" % (len(roots), G.getName())
+    if verbose : print("getLongestPath traversing %d roots in %s:" % (len(roots), G.getName()))
     for r in roots  :
         path = getLongest(r, memo)
         if not result or (len(path) > len(result)) : result = path
@@ -130,10 +130,10 @@ def getLongestPath(G, verbose=False) :
 def getLongest(node, memo, verbose=False) :
     """Recursive method that returns the longest path from the given node."""
     if node in memo :
-        if verbose : print "getLongest returning memoized path for", str(node)
+        if verbose : print("getLongest returning memoized path for", str(node))
         return memo[node]
     elif node.isLeaf() :
-        if verbose : print "getLongest returning leaf node for", str(node)
+        if verbose : print("getLongest returning leaf node for", str(node))
         result = SpliceGraphPath(node)
     else :
         result = None
@@ -142,6 +142,6 @@ def getLongest(node, memo, verbose=False) :
             path.update(getLongest(c,memo,verbose=verbose))
             if not result or (len(path) > len(result)) : result = path
         if not result : result = SpliceGraphPath(node)
-        if verbose : print "getLongest returning path of length", len(result)
+        if verbose : print("getLongest returning path of length", len(result))
     memo[node] = result
     return result

--- a/iDiffIR/SpliceGrapher/shared/adjust.py
+++ b/iDiffIR/SpliceGrapher/shared/adjust.py
@@ -76,17 +76,17 @@ def adjustDepths(depths, ranges, **args) :
     gaps      = getGaps(ranges)
     minpos    = ranges[0].minpos
     maxpos    = min(len(depths), ranges[-1].maxpos)
-    fullRange = range(minpos,maxpos+1)
+    fullRange = list(range(minpos,maxpos+1))
 
     # Easy part -- simply shift values within an exon:
     # Create map from positions to associated ranges
     rangeMap = {}.fromkeys(fullRange, None)
     for r in ranges :
-        for i in xrange(r.minpos,r.maxpos+1) :
+        for i in range(r.minpos,r.maxpos+1) :
             rangeMap[i] = r
 
     # Simply shift values that fall into exon ranges 
-    for i in xrange(minpos,maxpos) :
+    for i in range(minpos,maxpos) :
         if not rangeMap[i] : continue
         result[rangeMap[i].shift(i)] = depths[i]
 
@@ -95,7 +95,7 @@ def adjustDepths(depths, ranges, **args) :
     for g in gaps :
         # Associate gap with range that immediately precedes it:
         g.setShift(rangeMap[g.minpos-1].shift(g.minpos))
-        for i in xrange(g.minpos,g.maxpos+1) :
+        for i in range(g.minpos,g.maxpos+1) :
             gapMap[i] = g
 
     # Shift and scale values within an intron:
@@ -105,7 +105,7 @@ def adjustDepths(depths, ranges, **args) :
         gamma      = float(len(g))/intronSize
         # Each value of the shrunken intron is the average of
         # the values in its corresponding range:
-        for i in xrange(g.shiftedMin(), g.shiftedMin()+intronSize+1) :
+        for i in range(g.shiftedMin(), g.shiftedMin()+intronSize+1) :
             a         = g.minpos + int(round(gamma*(i-g.shiftedMin())))
             b         = int(round(a+gamma))
             result[i] = float(sum(depths[a:b+1]))/(b-a+1)
@@ -206,7 +206,7 @@ def adjustIntron(gap, **args) :
     gapSize     = len(gap)
     try :
         return min(logScale(gapSize,scaleFactor), gapSize)
-    except ValueError, ve :
+    except ValueError as ve :
         sys.stderr.write('Unable to rescale intron gap %s size %d\n' % (gap, gapSize))
         raise ve
 
@@ -260,7 +260,7 @@ def adjustRanges(rangeList, **args) :
     gaps = getGaps(rangeList)
     pos  = 0
     j    = 0
-    for i in xrange(len(rangeList)) :
+    for i in range(len(rangeList)) :
         r = rangeList[i]
         if i == 0 :
             newc = r
@@ -310,7 +310,7 @@ def closestRangeBelow(ranges, pos, **args) :
 def getGaps(ranges) :
     """Returns adjustable range instances for all the gaps between the ranges
     in the given list."""
-    gaps = [AdjustableRange(ranges[i-1].maxpos+1, ranges[i].minpos-1) for i in xrange(1,len(ranges))]
+    gaps = [AdjustableRange(ranges[i-1].maxpos+1, ranges[i].minpos-1) for i in range(1,len(ranges))]
     #assert(len(gaps) == len(ranges)-1)
     return gaps
 
@@ -324,7 +324,7 @@ def getGraphRanges(G, **args) :
     that represent all the overlapping nodes in the graph."""
     unresolved = getAttribute('unresolved', False, **args)
     if unresolved :
-        return getRanges(G.nodeDict.values(), **args)
+        return getRanges(list(G.nodeDict.values()), **args)
     else :
         return getRanges(G.resolvedNodes(), **args)
 

--- a/iDiffIR/SpliceGrapher/shared/dna.py
+++ b/iDiffIR/SpliceGrapher/shared/dna.py
@@ -43,7 +43,7 @@ def complement(s) :
     """
     try :
         return ''.join([COMPLEMENT[c] for c in s])
-    except KeyError, e :
+    except KeyError as e :
         raise ValueError("DNA sequence error")
 
 def reverseComplement(s) :

--- a/iDiffIR/SpliceGrapher/shared/utils.py
+++ b/iDiffIR/SpliceGrapher/shared/utils.py
@@ -18,7 +18,7 @@
 """
 Module containing general utility methods.
 """
-import ConfigParser, gzip, locale, os, random, subprocess, sys, time, streams
+import configparser, gzip, locale, os, random, subprocess, sys, time, streams
 from glob import glob
 
 def asList(value, delim=',') :
@@ -78,13 +78,13 @@ def commaFormat(d) :
 def configMap(cfgFile):
     """Reads a configuration file and returns a dictionary of all sections, options and values."""
     result = {}
-    config = ConfigParser.ConfigParser()
+    config = configparser.ConfigParser()
     # Activates case-sensitivity:
     config.optionxform = str
 
     try :
         config.read(cfgFile)
-    except ConfigParser.ParsingError :
+    except configparser.ParsingError :
         raise ValueError('Invalid configuration file %s' % cfgFile)
 
     for sect in config.sections() :
@@ -104,7 +104,7 @@ def dictString(valDict, delim=',') :
 def ezopen(fileName) :
     """Allows clients to open files without regard for whether they're gzipped."""
     if not (os.path.exists(fileName) and os.path.isfile(fileName)):
-        raise ValueError, 'file does not exist at %s' % fileName
+        raise ValueError('file does not exist at %s' % fileName)
     
     fileHandle  = gzip.GzipFile(fileName)
     gzippedFile = True
@@ -341,7 +341,7 @@ class RandomListIterator(object) :
     def __iter__(self) :
         return self
 
-    def next(self) :
+    def __next__(self) :
         """Iterator implementation that returns a random value, with
         replacement, from a list."""
         i = self.rand.randint(0,self.limit)

--- a/iDiffIR/SpliceGrapher/statistics/GraphStatistics.py
+++ b/iDiffIR/SpliceGrapher/statistics/GraphStatistics.py
@@ -32,7 +32,7 @@ def countFunctionName(asType) :
     try :
         return COUNT_FUNCTION[key]
     except KeyError :
-        raise ValueError('Unrecognized AS type for summary average: %s is not in %s' % (asType, '/'.join(EVENT_ABBREVS.keys())))
+        raise ValueError('Unrecognized AS type for summary average: %s is not in %s' % (asType, '/'.join(list(EVENT_ABBREVS.keys()))))
 
 class AbstractStatistics(object) :
     """Base class for all statistics classes."""
@@ -100,8 +100,8 @@ class GraphStatistics(AbstractStatistics) :
         # Count inter-group connections by identifying nodes in
         # one group that are children of nodes in the other.
         eventCount = 0
-        for i in xrange(len(groups)-1) :
-            for j in xrange(i+1,len(groups)) :
+        for i in range(len(groups)-1) :
+            for j in range(i+1,len(groups)) :
                 A     = groups[i]
                 B     = groups[j]
                 Akids = set([c for n in A for c in n.children])
@@ -208,7 +208,7 @@ class SummaryStatistics(AbstractStatistics) :
             indicator.update()
             try :
                 g = getFirstGraph(f)
-            except KeyError, ke :
+            except KeyError as ke :
                 raise KeyError('Invalid graph in file %s: %s' % (f,str(ke)))
             except ValueError :
                 continue
@@ -221,7 +221,7 @@ class SummaryStatistics(AbstractStatistics) :
         """Adds a set, dictionary or a list of graphs to the set.  Raises an
         exception if the instance has already loaded any of the graphs."""
         if type(graphs) == type({}) :
-            graphList = graphs.values()
+            graphList = list(graphs.values())
         elif type(graphs) == type(set([])) :
             graphList = list(graphs)
         elif type(graphs) == type([]) :
@@ -241,7 +241,7 @@ class SummaryStatistics(AbstractStatistics) :
         """Returns the total number of graphs stored that have AS.
         Note: ignores alternative initiating or terminating exons
         unless 'useAll' is set."""
-        return len([s for s in self.stats.values() if s.hasAS(useAll=useAll)])
+        return len([s for s in list(self.stats.values()) if s.hasAS(useAll=useAll)])
 
     def avg(self, asType) :
         """Returns the average value for the given AS type."""
@@ -253,12 +253,12 @@ class SummaryStatistics(AbstractStatistics) :
 
     def avgBranchingFactor(self) :
         """Returns the average branching factor per graph."""
-        total = sum([s.branchingFactor() for s in self.stats.values()])
+        total = sum([s.branchingFactor() for s in list(self.stats.values())])
         return self.computeAverage(total)
 
     def avgMaxBranchingFactor(self) :
         """Returns the average maximum branching factor per graph."""
-        total = sum([s.maxBranchingFactor() for s in self.stats.values()])
+        total = sum([s.maxBranchingFactor() for s in list(self.stats.values())])
         return self.computeAverage(total)
 
     def avgNodes(self) :
@@ -267,19 +267,19 @@ class SummaryStatistics(AbstractStatistics) :
 
     def computeAverage(self, count) :
         """Returns the average value given a sum, based on the number of graphs in this instance."""
-        N = len(self.stats.values())
+        N = len(list(self.stats.values()))
         return float(count)/N if N > 0 else 0.0
 
     def edgeCount(self) :
         """Returns the total number of edges in all graphs."""
         # Could use either parents or children
-        return sum([s.edgeCount() for s in self.stats.values()])
+        return sum([s.edgeCount() for s in list(self.stats.values())])
 
     def nodeCount(self) :
         """Returns the number of nodes in a graph."""
-        return sum([s.nodeCount() for s in self.stats.values()])
+        return sum([s.nodeCount() for s in list(self.stats.values())])
 
     def total(self, asType) :
         """Returns the total for the given AS type."""
         funcName = countFunctionName(asType)
-        return sum([getattr(s,funcName)() for s in self.stats.values()])
+        return sum([getattr(s,funcName)() for s in list(self.stats.values())])

--- a/scripts/get_intron_expression.py
+++ b/scripts/get_intron_expression.py
@@ -135,7 +135,7 @@ def loadData( nspace, geneModel ):
             genes     = geneModel.getGeneRecords(chrm)
             genes.sort()
 
-            for i in xrange(len(factorfiles)):
+            for i in range(len(factorfiles)):
                 fname = os.path.join(factorfiles[i], 
                                      '%s.cnt.gz' % chrm) 
                 if not os.path.exists(fname):
@@ -144,7 +144,7 @@ def loadData( nspace, geneModel ):
                 itr = fasta_itr( fname )
                 if nspace.verbose:
                     sys.stderr.write("Reading depths from %s\n" % ( fname ) )
-                rec = itr.next() 
+                rec = next(itr) 
                 key = rec.header
                 depths = numpy.array( rec.sequence.strip().split(), int )
                 counter = 0
@@ -192,13 +192,13 @@ def main():
                                                                nspace.factor2bamfiles 
                                                            )
         F1C = numpy.array([ [(f1EV[i][s:(e+1)]).mean() \
-                             for s,e in gene.exonsI] for i in xrange(len( f1EV))]).mean(0)
+                             for s,e in gene.exonsI] for i in range(len( f1EV))]).mean(0)
         F2C = numpy.array([ [(f2EV[i][s:(e+1)]).mean() \
-                             for s,e in gene.exonsI] for i in xrange(len( f2EV))]).mean(0)
+                             for s,e in gene.exonsI] for i in range(len( f2EV))]).mean(0)
         f1depth = numpy.mean(F1C)
         f2depth = numpy.mean(F2C)
         F1I = numpy.array([ [(f1EV[i][s:(e+1)]).mean() \
-                             for s,e in gene.introns] for i in xrange(len( f1EV))]).mean(0)
+                             for s,e in gene.introns] for i in range(len( f1EV))]).mean(0)
         ires1 = [ ]
         ires2 = [ ]
         nr1 = [ ]
@@ -207,25 +207,25 @@ def main():
             s,e = r
             if gene.retained[i]:
                 ires1.append( numpy.array([(f1EV[i][s:(e)]).mean() \
-                                           for i in xrange(len( f1EV))]).mean(0) )
+                                           for i in range(len( f1EV))]).mean(0) )
                 ires2.append( numpy.array([(f2EV[i][s:(e)]).mean() \
-                                           for i in xrange(len( f2EV))]).mean(0) )
+                                           for i in range(len( f2EV))]).mean(0) )
                 IRs.append( (ires1[-1] +  ires2[-1])/2.0) 
             else:
                 nr1.append( numpy.array([(f1EV[i][s:(e)]).mean() \
-                                           for i in xrange(len( f1EV))]).mean(0) )
+                                           for i in range(len( f1EV))]).mean(0) )
                 nr2.append( numpy.array([(f2EV[i][s:(e)]).mean() \
-                                           for i in xrange(len( f2EV))]).mean(0) )
+                                           for i in range(len( f2EV))]).mean(0) )
                 IEs.append( (nr1[-1] +  nr2[-1])/2.0) 
                 
         if len(ires1) > 0:
             ofile.write('%s\t%f\t%f\t%f\t%f\n' % ( gene.gid, f1depth, f2depth, numpy.mean(ires1), numpy.mean(ires2)))
         else:
             ofile.write('%s\t%f\t%f\t-\t-\n' % ( gene.gid, f1depth, f2depth) )
-    print numpy.sum( IRs > 0 )/ float(len(IRs))
-    print numpy.mean(IRs)
-    print numpy.sum( IEs > 0 )/ float(len(IEs))
-    print numpy.mean(IEs)
+    print(numpy.sum( IRs > 0 )/ float(len(IRs)))
+    print(numpy.mean(IRs))
+    print(numpy.sum( IEs > 0 )/ float(len(IEs)))
+    print(numpy.mean(IEs))
     ofile.close()
 
 if __name__ == "__main__":

--- a/scripts/make_MISO_SE_GFF.py
+++ b/scripts/make_MISO_SE_GFF.py
@@ -74,7 +74,7 @@ def getEventLocs( node ):
         children = list(set([( e.minpos, e.maxpos) for e in node.parents]))
         
     return [ (parents[i],(node.minpos,node.maxpos), children[j])\
-                 for i in xrange(len(parents)) for j in xrange(len(children))]
+                 for i in range(len(parents)) for j in range(len(children))]
 for gene in genes :
     if gene.chromosome not in chrCounter :
         chrCounter[gene.chromosome] = 0
@@ -84,7 +84,7 @@ for gene in genes :
     # Create splice graph for gene:
     try :
         geneGraph = makeSpliceGraph(gene)#geneModelToSpliceGraph(g)
-    except ValueError, ve:
+    except ValueError as ve:
         sys.stderr.write("Unable to create graph for %s\n" % gene.name)
         continue 
 

--- a/scripts/simulate_IR.py
+++ b/scripts/simulate_IR.py
@@ -165,7 +165,7 @@ def simulateReads( positions, sequence, chrom, strand, depth, length, qname, out
     L = len(sequence)
     nReads = depth * int(L/float(length))
     #nReads = depth * L
-    for _ in xrange( nReads ):
+    for _ in range( nReads ):
         simulateReads.n += 1
         rid = '%s.%d' % ( qname, simulateReads.n)
         idx = random.randint( 0, L-length )
@@ -182,7 +182,7 @@ def run_test( ):
     for gene in genes:
         gene_dict[gene.id] = gene
     gene       = gene_dict[diffIsos[0]]
-    print gene.id, gene.strand
+    print(gene.id, gene.strand)
 
     g = makeSpliceGraph(gene)
     g.annotate()
@@ -193,11 +193,11 @@ def run_test( ):
         as_map[key] = l
     if opts.verbose:
         sys.stderr.write('Creating differential isoform reads for %s\n' %  gene.id )
-    diffIso_n  = random.choice( range( len( gene.isoforms)))
+    diffIso_n  = random.choice( list(range( len( gene.isoforms))))
     mt_exp     = numpy.random.poisson( 50, 1 )
     mt_diffExp = int(mt_exp * 0.75)
     mt_eqExp   = max(1, int((mt_exp*0.25)/ (len(gene.isoforms)-1) ))
-    mt_IsoDepths = [ mt_diffExp if i == diffIso_n else mt_eqExp for i in xrange( len(gene.isoforms ) ) ]
+    mt_IsoDepths = [ mt_diffExp if i == diffIso_n else mt_eqExp for i in range( len(gene.isoforms ) ) ]
 
     wt_exp     = numpy.random.poisson( 50, 1 )
     wt_eqExp   = max(1, int(wt_exp/ float(len(gene.isoforms) )))
@@ -206,11 +206,11 @@ def run_test( ):
     wt_IsoDepths = [ wt_eqExp ] * len( gene.isoforms ) 
 
     for i,iso in enumerate(gene.isoforms):
-        exons = sorted( [sorted( [x.start(), x.end()] ) for x in gene.isoforms.values()[i].sortedExons() ] )
+        exons = sorted( [sorted( [x.start(), x.end()] ) for x in list(gene.isoforms.values())[i].sortedExons() ] )
         sequence = ''.join([ loader.subsequence( gene.chromosome, 
                                                  exon[0]-1, exon[1]-1, 
                                                  reverse=gene.strand=='-') for exon in exons])
-        positions = list(itertools.chain( *[range( x[0], x[1]+1) for x in exons ] ))
+        positions = list(itertools.chain( *[list(range( x[0], x[1]+1)) for x in exons ] ))
         simulateReads( positions, sequence, gene.chromosome, gene.strand, 
                        mt_IsoDepths[i], opts.read_length, 'mutant_1', mt_OutStream)
         simulateReads( positions, sequence, gene.chromosome, gene.strand, 
@@ -221,14 +221,14 @@ def run_test( ):
     os.system("""awk '$1 ~ /^@/{print $0;next}{print $0 | "sort -k 3,3 -k 4,4n"}' wildtype.sam > tmpFile && mv tmpFile wildtype.sam""")
     os.system("""awk '$1 ~ /^@/{print $0;next}{print $0 | "sort -k 3,3 -k 4,4n"}' mutant.sam > tmpFile && mv tmpFile mutant.sam""")
     evs = []
-    for start,end in sorted( [sorted( [x.start(), x.end()] ) for x in gene.isoforms.values()[i].sortedExons() ] ):
+    for start,end in sorted( [sorted( [x.start(), x.end()] ) for x in list(gene.isoforms.values())[i].sortedExons() ] ):
         key2 = (start,end)
         for key in as_map:
             if key == key2:
-                print key, as_map[key]
+                print(key, as_map[key])
             elif key2[0] >= key[0] and key2[1] >= key[1]:
-                print key, as_map[key]
-    print as_map
+                print(key, as_map[key])
+    print(as_map)
     template = \
                """[SinglePlotConfig]
 legend        = True
@@ -280,11 +280,11 @@ labels        = True
     os.system( 'plotter.py plot.config' )
     
 def makeSingleIsoform( gene, depths1, label1, outstream1, depths2, label2, outstream2, minAnchor ):
-    exons = sorted( [sorted( [x.start(), x.end()] ) for x in gene.isoforms.values()[0].sortedExons() ] )    
+    exons = sorted( [sorted( [x.start(), x.end()] ) for x in list(gene.isoforms.values())[0].sortedExons() ] )    
     sequence = ''.join([ loader.subsequence( gene.chromosome, 
                                              exon[0]-1, exon[1]-1, 
                                              reverse=gene.strand=='-') for exon in exons])
-    positions = list(itertools.chain( *[range( x[0], x[1]+1) for x in exons ] ))
+    positions = list(itertools.chain( *[list(range( x[0], x[1]+1)) for x in exons ] ))
     simulateReads( positions, sequence, gene.chromosome, gene.strand, 
                    depths1, opts.read_length, label1, outstream1, minAnchor)
     simulateReads( positions, sequence, gene.chromosome, gene.strand, 
@@ -292,11 +292,11 @@ def makeSingleIsoform( gene, depths1, label1, outstream1, depths2, label2, outst
     
 def makeMultiIsoform( gene,  depths1, label1, outstream1, depths2, label2, outstream2, minAnchor ):
     for i, iso in enumerate(gene.isoforms):
-        exons = sorted( [sorted( [x.start(), x.end()] ) for x in gene.isoforms.values()[i].sortedExons() ] )
+        exons = sorted( [sorted( [x.start(), x.end()] ) for x in list(gene.isoforms.values())[i].sortedExons() ] )
         sequence = ''.join([ loader.subsequence( gene.chromosome, 
                                                  exon[0]-1, exon[1]-1, 
                                                  reverse=gene.strand=='-') for exon in exons])
-        positions = list(itertools.chain( *[range( x[0], x[1]+1) for x in exons ] ))
+        positions = list(itertools.chain( *[list(range( x[0], x[1]+1)) for x in exons ] ))
         simulateReads( positions, sequence, gene.chromosome, gene.strand, 
                        depths1[i], opts.read_length, label1, outstream1, minAnchor)
         simulateReads( positions, sequence, gene.chromosome, gene.strand, 
@@ -305,7 +305,7 @@ def makeMultiIsoform( gene,  depths1, label1, outstream1, depths2, label2, outst
 def annotateIRs(gene):
     isoIRs = [ ]
     exons = set([( min(e.start(), e.end()), max(e.start(), e.end())) for e in gene.sortedExons()])
-    for iso in gene.isoforms.values():
+    for iso in list(gene.isoforms.values()):
         hasIR = False
         introns = [ sorted(x) for x in iso.sortedIntrons() ]
         for s,e in introns:
@@ -324,7 +324,7 @@ def main():
     IR_events = { }
     mt_OutStreams = [ ]
     wt_OutStreams = [ ]
-    for r in xrange(opts.reps):
+    for r in range(opts.reps):
         mt_OutStreams.append( open('mutant_%d.sam' % (r+1), 'w'))
         wt_OutStreams.append( open('wildtype_%d.sam' % (r+1), 'w'))
 
@@ -393,7 +393,7 @@ def main():
                 summary_stream.write( '%s\t%d\t%d\t%s\t' % (gene.id, up_depth, dn_depth, 'False' ))
         # only one isoform
         if len( gene.isoforms ) < 2:
-            for r in xrange(opts.reps):
+            for r in range(opts.reps):
                 makeSingleIsoform( gene, up_depth, up_label, up_outstreams[r], dn_depth, dn_label, dn_outstreams[r], opts.minAnchor )
             summary_stream.write('False\t\n')
             continue
@@ -408,12 +408,12 @@ def main():
             l = as_map.get(key, set([]))
             l.add( ev[2] )
             as_map[key] = l
-        diffIso_n  = random.choice( range( len( gene.isoforms)))
-        diso = gene.isoforms.values()[diffIso_n]
+        diffIso_n  = random.choice( list(range( len( gene.isoforms))))
+        diso = list(gene.isoforms.values())[diffIso_n]
         # get differntial IR events, if there are any in the selected isoform
         evs = set([])
         diso_start, diso_end = sorted( (diso.start(), diso.end()) )
-        did = gene.isoforms.keys()[diffIso_n]
+        did = list(gene.isoforms.keys())[diffIso_n]
         for start,end in sorted( [sorted( [x.start(), x.end()] ) for x in diso.sortedExons() ] ):
             key2 = (start,end)
             for key in as_map:
@@ -421,21 +421,21 @@ def main():
                     if 'IR' in as_map[key]:
                         evs.add( (start, end, 'P') )
 
-        for j in xrange ( len ( gene.isoforms ) ):
+        for j in range ( len ( gene.isoforms ) ):
             if j == diffIso_n: continue
-            for start,end in sorted( [sorted( [x.start(), x.end()] ) for x in gene.isoforms.values()[j].sortedExons() ] ):
+            for start,end in sorted( [sorted( [x.start(), x.end()] ) for x in list(gene.isoforms.values())[j].sortedExons() ] ):
                 key2 = (start,end)
                 for key in as_map:
                     if key == key2:
                         if 'IR' in as_map[key] and (start >= diso_start and start <= diso_end or end >= diso_start and end <= diso_end):
                             evs.add( (start, end, 'S') )
             
-        lambdasEq = numpy.array([ max(0.15,ire) if irIsos[i] else max(0.15,1.0-ire) for i in xrange( len( gene.isoforms ) ) ])
+        lambdasEq = numpy.array([ max(0.15,ire) if irIsos[i] else max(0.15,1.0-ire) for i in range( len( gene.isoforms ) ) ])
         lambdasEq = lambdasEq/sum(lambdasEq)
         isoScalar = random.uniform(1.5,5)
         if random.randint(0,1):
             isoScalar = 1.0 / isoScalar 
-        lambdasDiff = numpy.array( [ isoScalar*lambdasEq[i] if i == diffIso_n else lambdasEq[i] for i in xrange( len(gene.isoforms))])
+        lambdasDiff = numpy.array( [ isoScalar*lambdasEq[i] if i == diffIso_n else lambdasEq[i] for i in range( len(gene.isoforms))])
         lambdasDiff = lambdasDiff/sum(lambdasDiff)
 
         if gene.id in diffIsos:
@@ -469,10 +469,10 @@ def main():
             eiso_outstreams = dn_outstreams
             eiso_depths =  [ int(x) for x in lambdasEq*dn_depth]
             summary_stream.write('False\t\n')            
-        for r in xrange(opts.reps):
+        for r in range(opts.reps):
             makeMultiIsoform( gene,  diso_depths, diso_label, diso_outstreams[r], eiso_depths, eiso_label, eiso_outstreams[r], opts.minAnchor )
     indicator.finish()
-    for r in xrange(opts.reps):
+    for r in range(opts.reps):
         mt_OutStreams[r].close()
         wt_OutStreams[r].close()
     summary_stream.close()


### PR DESCRIPTION
### Motivation
- Update the legacy iDiffIR scripts and bundled SpliceGrapher modules to use modern Python 3 syntax so the code compiles under Python 3 and is easier to maintain.
- Remove Python-2-only constructs that caused syntax errors under `python3` (e.g., `print` statements, `xrange`, old exception syntax, iterator `.next()`, dict view usage, and `ConfigParser`).

### Description
- Rewrote legacy constructs across core scripts and libraries (roughly 26 files under `scripts/` and `iDiffIR/SpliceGrapher/`) including `print` → `print(...)`, `xrange` → `range`, `.next()` → `next(...)` and iterator `__next__`, `except X, e` → `except X as e`, and `raise ValueError, 'msg'` → `raise ValueError('msg')`.
- Normalized collection/view semantics for Python 3 by wrapping `.keys()/.values()` with `list()` where appropriate and converting `range(...)`/`list(range(...))` usage; replaced `ConfigParser` with `configparser` and `sys.maxint` with `sys.maxsize`.
- Fixed iterator/ID generator usage to Python 3 semantics (e.g., `idgen.next()` → `next(idgen)`) and updated other small incompatibilities across fasta/format loaders, parsers, and utilities.
- Applied automated 2to3 refactoring where useful and finished hand edits to remove remaining Python-2-only syntax so the codebase is syntactically valid for Python 3.

### Testing
- Ran `python3 -m py_compile scripts/idiffir.py` to validate the main script syntax, which completed without syntax errors.
- Ran `python3 -m compileall -q scripts iDiffIR` before changes and observed multiple Python 2 syntax errors, then re-ran it after the modernization and it completed successfully with no syntax errors reported.
- Attempted `python3 scripts/idiffir.py --help` but runtime execution failed due to missing runtime dependencies (e.g., NumPy/PySAM) in the environment, so functional/runtime tests were not performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69955fcaf9708333a87f151db05df722)