### PR TITLE
Modernize Python packaging metadata and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install project and test dependencies
+        run: uv sync --extra test
+
+      - name: Build wheel
+        run: uv run python -m pip install build && uv run python -m build
+
+      - name: Validate wheel install
+        run: uv run python -m pip install --force-reinstall dist/*.whl
+
+      - name: Run tests
+        run: uv run pytest

--- a/README
+++ b/README
@@ -1,21 +1,51 @@
-Developed for Python 2.x--refactor in progress (2024 branch)
+# iDiffIR
 
-Install
------------
- python setup.py build
+iDiffIR identifies differential intron retention from RNA-seq data.
 
- python setup.py install
+## Python support
 
+Python 2 is **formally dropped**. This project supports Python:
 
-**Note**:
+- 3.9
+- 3.10
+- 3.11
+- 3.12
 
-To install to a local set of python libraries
-use --home=/PATH/TO/LOCAL/LIBRARY
+## Installation and development with `uv`
 
-Required Packages
--------------------------
+### One-time setup
 
-- SciPy
-- Pysam
-- matplotlib
-- NumPy
+```bash
+uv sync --extra dev
+```
+
+This creates/uses a local virtual environment and installs project + development dependencies from `uv.lock`.
+
+### Run tests
+
+```bash
+uv run pytest
+```
+
+### Run project scripts/tools
+
+Use `uv run` for project commands, for example:
+
+```bash
+uv run python scripts/idiffir.py --help
+```
+
+Use `uv tool` for standalone CLI tools that are not project dependencies, for example:
+
+```bash
+uv tool run ruff --version
+```
+
+## Packaging
+
+The project uses PEP 621 metadata in `pyproject.toml` with the `setuptools.build_meta` backend.
+
+Runtime dependencies are declared in `project.dependencies`, with optional groups in:
+
+- `project.optional-dependencies.dev`
+- `project.optional-dependencies.test`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,56 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "iDiffIR"
+version = "0.3.1"
+description = "Identifying differential intron retention from RNA-seq"
+readme = "README"
+requires-python = ">=3.9"
+license = { text = "GNU General Public License" }
+authors = [
+  { name = "Michael Hamilton", email = "mike.hamilton7@gmail.com" },
+]
+urls = { Homepage = "https://combi.cs.colostate.edu/idiffir" }
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "License :: OSI Approved :: GNU General Public License (GPL)",
+  "Operating System :: OS Independent",
+]
+dependencies = [
+  "scipy",
+  "numpy",
+  "matplotlib",
+  "pysam",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+  "build>=1.2",
+]
+test = [
+  "pytest>=8.0",
+]
+
+[tool.setuptools]
+include-package-data = true
+script-files = [
+  "scripts/idiffir.py",
+  "scripts/getDepths.py",
+  "scripts/convertSam.py",
+  "scripts/simulate_IR.py",
+  "scripts/make_MISO_IR_GFF.py",
+  "scripts/make_MISO_AS_GFF.py",
+  "scripts/get_gene_expression.py",
+  "scripts/idiffir_plotter.py",
+  "scripts/run_miso_ir.py",
+]
+
+[tool.setuptools.packages.find]
+include = ["iDiffIR*"]

--- a/setup.py
+++ b/setup.py
@@ -1,62 +1,10 @@
 #!/usr/bin/env python
+"""Legacy setup shim.
+
+Prefer PEP 517/518 builds via `pyproject.toml`.
 """
-Distribution script for DinrSR, a program to identify
-differntial intron retention from short read data.
 
-\author Mike Hamilton
-"""
-from distutils.core import setup
-import sys
-SCRIPTS  = ['scripts/idiffir.py',
-            'scripts/getDepths.py',
-            'scripts/convertSam.py',
-            'scripts/simulate_IR.py',
-            'scripts/make_MISO_IR_GFF.py',
-            'scripts/make_MISO_AS_GFF.py',
-            'scripts/get_gene_expression.py',
-            'scripts/idiffir_plotter.py',
-            'scripts/run_miso_ir.py'            
-]
+from setuptools import setup
 
-PACKAGES = [ 'iDiffIR',
-             'iDiffIR.SpliceGrapher',
-             'iDiffIR.SpliceGrapher.formats',
-             'iDiffIR.SpliceGrapher.plot',
-             'iDiffIR.SpliceGrapher.predict',
-             'iDiffIR.SpliceGrapher.shared',
-             'iDiffIR.SpliceGrapher.statistics',
-             'iDiffIR.SpliceGrapher.view',
-]
-
-
-REQUIRES = ['scipy',
-            'numpy',
-            'matplotlib',
-            'pysam'
-]
-
-# check for dependencies if we're building or installing
-installable = True
-if 'build' in sys.argv or 'install' in sys.argv:
-    sys.stderr.write('Checking for dependencies...\n')
-    for package in REQUIRES:
-        try:
-            p = __import__( package )
-            sys.stderr.write('package "%s" found (version %s)\n' % (package, p.__version__))
-        except ImportError:
-            installable = False
-            sys.stderr.write('\tRequired package `%s` not found\n' % package )
-    if not installable:
-        sys.exit('Missing dependencies--terminating installation')
-
-setup(name='iDiffIR',
-      version='0.3.1',
-      description='Identifying differential intron retention from RNA-seq',
-      author='Michael Hamilton',
-      author_email='mike.hamilton7@gmail.com',
-      url='combi.cs.colostate.edu/idiffir',
-      packages=PACKAGES,
-      requires=REQUIRES,
-      scripts=SCRIPTS,
-      license='GNU General Public License'
-     )
+if __name__ == "__main__":
+    setup()

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,5 @@
+import iDiffIR
+
+
+def test_version_present():
+    assert hasattr(iDiffIR, "__version__")


### PR DESCRIPTION
### Motivation
- Move legacy metadata and dependency declarations out of `setup.py` to modern PEP 621/PEP 517 tooling for more robust installer resolution.
- Remove fragile import-time dependency checks and rely on installer metadata instead.
- Formalize supported Python versions and drop Python 2 to simplify maintenance.
- Add a reproducible developer workflow and CI matrix to validate packaging and tests across supported Python versions.

### Description
- Added `pyproject.toml` with `setuptools.build_meta` and migrated package metadata to `project.*`, replacing `requires=` with `project.dependencies` and adding optional groups `dev` and `test`.
- Replaced the previous `setup.py` logic with a minimal legacy shim that calls `setuptools.setup()` and removed import-time dependency checks.
- Updated `README` to document the `uv` workflow including `uv sync --extra dev`, `uv run pytest`, and `uv tool` usage, and declared support for Python 3.9–3.12 while dropping Python 2.
- Added a GitHub Actions workflow `.github/workflows/ci.yml` that creates a packaging + test matrix across Python 3.9–3.12 and added a minimal pytest smoke test at `tests/test_import.py`.

### Testing
- Ran `python -m pytest -q tests`, which passed (`1 passed`).
- Performed editable installation with `python -m pip install -e . --no-deps --no-build-isolation`, which succeeded and produced an editable wheel.
- Attempted `uv lock` and `uv sync --extra test`, but these failed in this environment due to blocked network access to PyPI, so an `uv.lock` could not be generated here and CI was not executed locally.
- Building a wheel with `python -m build` was not available in this environment without network access to install build tools, but the editable install path validated package metadata locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699563223c9c83339374e8911fa36281)