### PR TITLE
refactor(cli): harden legacy script startup paths and smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ doc/_build
 *.pyc
 release/
 iDiffIR_v*
+iDiffIR.egg-info/

--- a/scripts/make_MISO_SE_GFF.py
+++ b/scripts/make_MISO_SE_GFF.py
@@ -11,59 +11,26 @@ from glob     import glob
 from optparse import OptionParser
 import os, sys, warnings
 
-parser = OptionParser(usage='Generate GFF file for MISO of exon skipping events')
-parser.add_option('-m', dest='model',    default=SG_GENE_MODEL, help='Gene model GFF file [default: %default]')
-parser.add_option('-o', dest='outfile',  default=None,          help='Output file [default: %default]')
-parser.add_option('-v', dest='verbose',  default=False,         help='Verbose mode [default: %default]', action='store_true')
-parser.add_option( '-s', dest='graphPaths', default=None, help='File containing paths to splice graphs to augment gene models')
-opts, args = parser.parse_args(sys.argv[1:])
+def build_parser():
+    parser = OptionParser(usage='Generate GFF file for MISO of exon skipping events')
+    parser.add_option('-m', dest='model', default=SG_GENE_MODEL, help='Gene model GFF file [default: %default]')
+    parser.add_option('-o', dest='outfile', default=None, help='Output file [default: %default]')
+    parser.add_option('-v', dest='verbose', default=False, help='Verbose mode [default: %default]', action='store_true')
+    parser.add_option('-s', dest='graphPaths', default=None, help='File containing paths to splice graphs to augment gene models')
+    return parser
 
-#-------------------------------------------------------
-# Main program
-#-------------------------------------------------------
-opts, args = parser.parse_args(sys.argv[1:])
 
-errStrings = []
-if not opts.model : errStrings.append('** No GFF gene model specified.  Set SPLICEGRAPHER_GENE_MODEL or use the -m option.')
-if errStrings :
-    parser.print_help()
-    sys.stderr.write('\n%s\n' % '\n'.join(errStrings))
-    sys.exit(1)
-
-geneModel = loadGeneModels(opts.model, verbose=opts.verbose, alltypes=True)
-genes     = geneModel.getAllGenes(geneFilter=gene_type_filter)
-genes.sort()
-
-outStream = open(opts.outfile, 'w') if opts.outfile else sys.stdout
-
-totalRecs  = 0
-uniqueEvents = 0
-exceptions = set([])
-chrCounter = {}
-indicator = ProgressIndicator(10000, description=' genes', verbose=opts.verbose)
-
-if opts.graphPaths != None:
-    if opts.verbose: sys.stderr.write('Loading aux. splice graphs\n')
-    indicator = ProgressIndicator(10000, description=' files', verbose=opts.verbose)
-    with open( opts.graphPaths, 'r' ) as fin:
-        for line in fin:
-            fname = line.strip()
-            if not os.path.exists(fname):
-                if opts.verbose:
-                    sys.stderr.write('Missing splice graph file: %s\n' % fname)
-                    continue
-            indicator.update()
-            graph = getFirstGraph( fname )
-            geneName = graph.name.upper()
-            if geneName in spliceGraphs:
-                spliceGraphs[geneName] = spliceGraphs[geneName].union( graph )
-            else:
-                spliceGraphs[geneName] = graph
-            #for node in graph.unresolvedNodes():
-            #    spliceGraphs[geneName].addNode( node.id, node.start, node.end)
-
-    indicator.finish()
-    if opts.verbose : sys.stderr.write('Loaded %d aux. splice graphs\n' % (indicator.ctr))
+def parse_args(argv=None):
+    parser = build_parser()
+    opts, args = parser.parse_args(argv)
+    errStrings = []
+    if not opts.model:
+        errStrings.append('** No GFF gene model specified.  Set SPLICEGRAPHER_GENE_MODEL or use the -m option.')
+    if errStrings:
+        parser.print_help()
+        sys.stderr.write('\n%s\n' % '\n'.join(errStrings))
+        raise SystemExit(1)
+    return opts, args
 
 def getEventLocs( node ):
     if node.strand == '+':
@@ -75,86 +42,116 @@ def getEventLocs( node ):
 
     return [ (parents[i],(node.minpos,node.maxpos), children[j])\
                  for i in range(len(parents)) for j in range(len(children))]
-for gene in genes :
-    if gene.chromosome not in chrCounter :
-        chrCounter[gene.chromosome] = 0
-    #if opts.verbose : indicator.update()
 
 
-    # Create splice graph for gene:
-    try :
-        geneGraph = makeSpliceGraph(gene)#geneModelToSpliceGraph(g)
-    except ValueError as ve:
-        sys.stderr.write("Unable to create graph for %s\n" % gene.name)
-        continue
-
-    if geneGraph.name.upper() in spliceGraphs:
-        geneGraph = geneGraph.union(spliceGraphs[ geneGraph.name.upper() ])
-    geneGraph.annotate()
-
-
-    if not geneGraph.hasAS(): continue
-    if 'SE' not in geneGraph.altForms(): continue
-
-    seNodes = [node for node in geneGraph.resolvedNodes() if node.isSkippedExon()]
-
-
-    for nNum,node in enumerate(seNodes):
-        uniqueEvents += 1
-        nInt = 0
-        for exon5, exonS, exon3 in getEventLocs(node):
-            exon5, exonS, exon3
-            totalRecs += 1
-            nInt+=1
-            eventID = '%s:%d-%d:%d:%d' % (gene.id, exonS[0], exonS[1], nNum+1, nInt)
-            outStream.write('%s\tIR\tgene\t%d\t%d\t.\t%s\t.\tID=%s;Name=%s\n' % (gene.chromosome,
-                                                                                 exon5[0],
-                                                                                 exon3[1],
-                                                                                 node.strand,
-                                                                                 eventID, eventID))
-
-            irID = '%s:%d-%d:%d:%d' % (gene.id, exonS[0], exonS[1], nNum+1, nInt)
-            #make mRNA record for SE
-            outStream.write('%s\tSE\tmRNA\t%d\t%d\t.\t%s\t.\tID=%s:SE;Parent=%s\n' % \
-                                (gene.chromosome, exon5[0], exon3[1], node.strand,
-                                 irID, eventID))
-            #make mRNA record for CS
-            outStream.write('%s\tSE\tmRNA\t%d\t%d\t.\t%s\t.\tID=%s:CS;Parent=%s\n' % \
-                                (gene.chromosome,  exon5[0], exon3[1], node.strand,
-                                 irID, eventID))
-            #make 5' exon record for SE
-            outStream.write('%s\tSE\texon\t%d\t%d\t.\t%s\t.\tID=%s:se5Exon;Parent=%s:SE\n' % \
-                                (gene.chromosome, exon5[0], exon5[1], node.strand,
-                                 irID, irID))
-            #make 3' exon record for SE
-            outStream.write('%s\tSE\texon\t%d\t%d\t.\t%s\t.\tID=%s:se3Exon;Parent=%s:SE\n' % \
-                                (gene.chromosome, exon3[0], exon3[1], node.strand,
-                                 irID, irID))
-
-            #make 5' exon record for CS
-            outStream.write('%s\tSE\texon\t%d\t%d\t.\t%s\t.\tID=%s:se5Exon;Parent=%s:CS\n' % \
-                                (gene.chromosome, exon5[0], exon5[1], node.strand,
-                                 irID, irID))
-            #make 3' exon record for CS
-            outStream.write('%s\tSE\texon\t%d\t%d\t.\t%s\t.\tID=%s:se3Exon;Parent=%s:CS\n' % \
-                                (gene.chromosome, exon3[0], exon3[1], node.strand,
-                                 irID, irID))
-            #make cassette exon record for CS
-            outStream.write('%s\tSE\texon\t%d\t%d\t.\t%s\t.\tID=%s:cassExon;Parent=%s:CS\n' % \
-                                (gene.chromosome, exonS[0], exonS[1], node.strand,
-                                 irID, irID))
+def load_splice_graphs(graph_paths, verbose):
+    spliceGraphs = {}
+    if graph_paths is not None:
+        if verbose:
+            sys.stderr.write('Loading aux. splice graphs\n')
+        indicator = ProgressIndicator(10000, description=' files', verbose=verbose)
+        with open(graph_paths, 'r') as fin:
+            for line in fin:
+                fname = line.strip()
+                if not os.path.exists(fname):
+                    if verbose:
+                        sys.stderr.write('Missing splice graph file: %s\n' % fname)
+                    continue
+                indicator.update()
+                graph = getFirstGraph(fname)
+                geneName = graph.name.upper()
+                if geneName in spliceGraphs:
+                    spliceGraphs[geneName] = spliceGraphs[geneName].union(graph)
+                else:
+                    spliceGraphs[geneName] = graph
+        indicator.finish()
+        if verbose:
+            sys.stderr.write('Loaded %d aux. splice graphs\n' % indicator.ctr)
+    return spliceGraphs
 
 
+def main(argv=None):
+    opts, _ = parse_args(argv)
+    geneModel = loadGeneModels(opts.model, verbose=opts.verbose, alltypes=True)
+    genes = geneModel.getAllGenes(geneFilter=gene_type_filter)
+    genes.sort()
+    spliceGraphs = load_splice_graphs(opts.graphPaths, opts.verbose)
+
+    totalRecs = 0
+    uniqueEvents = 0
+    chrCounter = {}
+    indicator = ProgressIndicator(10000, description=' genes', verbose=opts.verbose)
+
+    outStream = open(opts.outfile, 'w') if opts.outfile else sys.stdout
+    try:
+        for gene in genes:
+            if gene.chromosome not in chrCounter:
+                chrCounter[gene.chromosome] = 0
+
+            # Create splice graph for gene:
+            try:
+                geneGraph = makeSpliceGraph(gene)
+            except ValueError:
+                sys.stderr.write("Unable to create graph for %s\n" % gene.name)
+                continue
+
+            if geneGraph.name.upper() in spliceGraphs:
+                geneGraph = geneGraph.union(spliceGraphs[geneGraph.name.upper()])
+            geneGraph.annotate()
+
+            if not geneGraph.hasAS():
+                continue
+            if 'SE' not in geneGraph.altForms():
+                continue
+
+            seNodes = [node for node in geneGraph.resolvedNodes() if node.isSkippedExon()]
+
+            for nNum, node in enumerate(seNodes):
+                uniqueEvents += 1
+                nInt = 0
+                for exon5, exonS, exon3 in getEventLocs(node):
+                    totalRecs += 1
+                    nInt += 1
+                    eventID = '%s:%d-%d:%d:%d' % (gene.id, exonS[0], exonS[1], nNum + 1, nInt)
+                    outStream.write('%s\tIR\tgene\t%d\t%d\t.\t%s\t.\tID=%s;Name=%s\n' % (
+                        gene.chromosome, exon5[0], exon3[1], node.strand, eventID, eventID))
+
+                    irID = '%s:%d-%d:%d:%d' % (gene.id, exonS[0], exonS[1], nNum + 1, nInt)
+                    # make mRNA record for SE
+                    outStream.write('%s\tSE\tmRNA\t%d\t%d\t.\t%s\t.\tID=%s:SE;Parent=%s\n' % (
+                        gene.chromosome, exon5[0], exon3[1], node.strand, irID, eventID))
+                    # make mRNA record for CS
+                    outStream.write('%s\tSE\tmRNA\t%d\t%d\t.\t%s\t.\tID=%s:CS;Parent=%s\n' % (
+                        gene.chromosome, exon5[0], exon3[1], node.strand, irID, eventID))
+                    # make 5' exon record for SE
+                    outStream.write('%s\tSE\texon\t%d\t%d\t.\t%s\t.\tID=%s:se5Exon;Parent=%s:SE\n' % (
+                        gene.chromosome, exon5[0], exon5[1], node.strand, irID, irID))
+                    # make 3' exon record for SE
+                    outStream.write('%s\tSE\texon\t%d\t%d\t.\t%s\t.\tID=%s:se3Exon;Parent=%s:SE\n' % (
+                        gene.chromosome, exon3[0], exon3[1], node.strand, irID, irID))
+
+                    # make 5' exon record for CS
+                    outStream.write('%s\tSE\texon\t%d\t%d\t.\t%s\t.\tID=%s:se5Exon;Parent=%s:CS\n' % (
+                        gene.chromosome, exon5[0], exon5[1], node.strand, irID, irID))
+                    # make 3' exon record for CS
+                    outStream.write('%s\tSE\texon\t%d\t%d\t.\t%s\t.\tID=%s:se3Exon;Parent=%s:CS\n' % (
+                        gene.chromosome, exon3[0], exon3[1], node.strand, irID, irID))
+                    # make cassette exon record for CS
+                    outStream.write('%s\tSE\texon\t%d\t%d\t.\t%s\t.\tID=%s:cassExon;Parent=%s:CS\n' % (
+                        gene.chromosome, exonS[0], exonS[1], node.strand, irID, irID))
+    finally:
+        if outStream is not sys.stdout:
+            outStream.close()
+
+    if opts.verbose:
+        indicator.finish()
+
+    sys.stderr.write("Wrote %d total SE events\n" % totalRecs)
+    sys.stderr.write("Wrote %d unique SE events\n" % uniqueEvents)
+    return 0
 
 
-
-
-outStream.flush()
-outStream.close()
-if opts.verbose : indicator.finish()
-
-sys.stderr.write("Wrote %d total SE events\n" % totalRecs)
-sys.stderr.write("Wrote %d unique SE events\n" % uniqueEvents)
-
+if __name__ == '__main__':
+    raise SystemExit(main())
 
 

--- a/tests/test_smoke_cli.py
+++ b/tests/test_smoke_cli.py
@@ -2,26 +2,44 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = [
+    "scripts/convertSam.py",
+    "scripts/getDepths.py",
+    "scripts/get_gene_expression.py",
+    "scripts/get_intron_expression.py",
+    "scripts/idiffir.py",
+    "scripts/idiffir_plotter.py",
+    "scripts/make_MISO_AS_GFF.py",
+    "scripts/make_MISO_IR_GFF.py",
+    "scripts/make_MISO_SE_GFF.py",
+    "scripts/run_miso_ir.py",
+    "scripts/simulate_IR.py",
+]
 
 
-def run_help(script_path: str):
+def run_help(script_path: str, cwd: Path | None = None):
     return subprocess.run(
         [sys.executable, str(ROOT / script_path), "--help"],
+        cwd=cwd,
         capture_output=True,
         text=True,
         check=False,
     )
 
 
-def test_idiffir_help_runs():
-    result = run_help("scripts/idiffir.py")
+@pytest.mark.parametrize("script_path", SCRIPTS)
+def test_script_help_runs(script_path):
+    result = run_help(script_path)
     assert result.returncode == 0, result.stderr
-    assert "usage: idiffir.py" in result.stdout
+    assert "usage" in result.stdout.lower()
 
 
-def test_convert_sam_help_runs():
-    result = run_help("scripts/convertSam.py")
+def test_make_miso_as_help_has_no_side_effect_files(tmp_path: Path):
+    result = run_help("scripts/make_MISO_AS_GFF.py", cwd=tmp_path)
     assert result.returncode == 0, result.stderr
-    assert "usage: convertSam.py" in result.stdout
+    assert not (tmp_path / "a3Maps.txt").exists()
+    assert not (tmp_path / "a5Maps.txt").exists()

--- a/tests/test_smoke_imports.py
+++ b/tests/test_smoke_imports.py
@@ -29,3 +29,7 @@ def test_core_modules_import():
     load_script_module("script_idiffir_plotter", "scripts/idiffir_plotter.py")
     load_script_module("script_get_intron_expression", "scripts/get_intron_expression.py")
     load_script_module("script_get_gene_expression", "scripts/get_gene_expression.py")
+    load_script_module("script_make_miso_as_gff", "scripts/make_MISO_AS_GFF.py")
+    load_script_module("script_make_miso_ir_gff", "scripts/make_MISO_IR_GFF.py")
+    load_script_module("script_make_miso_se_gff", "scripts/make_MISO_SE_GFF.py")
+    load_script_module("script_simulate_ir", "scripts/simulate_IR.py")


### PR DESCRIPTION
## Summary
- move legacy MISO/simulation scripts to guarded entrypoints (`parse_args` + `main`) so imports do not parse CLI args
- remove import-time side effects (including `a3Maps.txt`/`a5Maps.txt` creation on `--help` path)
- expand smoke coverage for all script `--help` entrypoints and import safety for legacy scripts

## Test Plan
- uv run pytest -q
- uv run python scripts/make_MISO_AS_GFF.py --help
- uv run python scripts/make_MISO_IR_GFF.py --help
- uv run python scripts/make_MISO_SE_GFF.py --help
- uv run python scripts/simulate_IR.py --help
