### PR TITLE
refactor(cli): migrate legacy scripts from optparse to argparse

### DIFF
--- a/scripts/make_MISO_AS_GFF.py
+++ b/scripts/make_MISO_AS_GFF.py
@@ -8,7 +8,7 @@ from iDiffIR.SpliceGrapher.SpliceGraph         import *
 from iDiffIR.SpliceGrapher.formats.loader import loadGeneModels
 
 from glob     import glob
-from optparse import OptionParser
+import argparse
 import os
 import sys
 
@@ -227,17 +227,17 @@ class AltEvent(object):
         self.label = label
 
 def build_parser():
-    parser = OptionParser()
-    parser.add_option('-m', dest='model',    default=SG_GENE_MODEL, help='Gene model GFF file [default: %default]')
-    parser.add_option('-o', dest='outbase',  default='AS',          help='Output file base')
-    parser.add_option('-v', dest='verbose',  default=False,         help='Verbose mode [default: %default]', action='store_true')
-    parser.add_option('-s', dest='graphPaths', default=None, help='File containing paths to splice graphs to augment gene models')
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-m', dest='model', default=SG_GENE_MODEL, help='Gene model GFF file [default: %(default)s]')
+    parser.add_argument('-o', dest='outbase', default='AS', help='Output file base')
+    parser.add_argument('-v', dest='verbose', default=False, help='Verbose mode [default: %(default)s]', action='store_true')
+    parser.add_argument('-s', dest='graphPaths', default=None, help='File containing paths to splice graphs to augment gene models')
     return parser
 
 
 def parse_args(argv=None):
     parser = build_parser()
-    opts, args = parser.parse_args(argv)
+    opts = parser.parse_args(argv)
     errStrings = []
     if not opts.model:
         errStrings.append('** No GFF gene model specified.  Set SPLICEGRAPHER_GENE_MODEL or use the -m option.')
@@ -245,7 +245,7 @@ def parse_args(argv=None):
         parser.print_help()
         sys.stderr.write('\n%s\n' % '\n'.join(errStrings))
         raise SystemExit(1)
-    return opts, args
+    return opts, []
 
 
 def load_splice_graphs(graph_paths, verbose):

--- a/scripts/make_MISO_IR_GFF.py
+++ b/scripts/make_MISO_IR_GFF.py
@@ -8,7 +8,7 @@ from iDiffIR.SpliceGrapher.SpliceGraph         import *
 from iDiffIR.SpliceGrapher.formats.loader import loadGeneModels
 
 from glob     import glob
-from optparse import OptionParser
+import argparse
 import os, sys, warnings, numpy
 
 def writeIntrons( gene, introns, label, outstream ):
@@ -139,16 +139,16 @@ def getGraphIntrons(graph, chrom) :
     return resIR, resIE
 
 def build_parser():
-    parser = OptionParser()
-    parser.add_option('-m', dest='model', default=SG_GENE_MODEL, help='Gene model GFF file [default: %default]')
-    parser.add_option('-o', dest='outfile', default='out.gff', help='Output file base')
-    parser.add_option('-v', dest='verbose', default=False, help='Verbose mode [default: %default]', action='store_true')
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-m', dest='model', default=SG_GENE_MODEL, help='Gene model GFF file [default: %(default)s]')
+    parser.add_argument('-o', dest='outfile', default='out.gff', help='Output file base')
+    parser.add_argument('-v', dest='verbose', default=False, help='Verbose mode [default: %(default)s]', action='store_true')
     return parser
 
 
 def parse_args(argv=None):
     parser = build_parser()
-    opts, args = parser.parse_args(argv)
+    opts = parser.parse_args(argv)
     errStrings = []
     if not opts.model:
         errStrings.append('** No GFF gene model specified.  Set SPLICEGRAPHER_GENE_MODEL or use the -m option.')
@@ -156,7 +156,7 @@ def parse_args(argv=None):
         parser.print_help()
         sys.stderr.write('\n%s\n' % '\n'.join(errStrings))
         raise SystemExit(1)
-    return opts, args
+    return opts, []
 
 
 def main(argv=None):

--- a/scripts/make_MISO_SE_GFF.py
+++ b/scripts/make_MISO_SE_GFF.py
@@ -8,21 +8,21 @@ from iDiffIR.SpliceGrapher.SpliceGraph         import *
 from iDiffIR.SpliceGrapher.formats.loader import loadGeneModels
 
 from glob     import glob
-from optparse import OptionParser
+import argparse
 import os, sys, warnings
 
 def build_parser():
-    parser = OptionParser(usage='Generate GFF file for MISO of exon skipping events')
-    parser.add_option('-m', dest='model', default=SG_GENE_MODEL, help='Gene model GFF file [default: %default]')
-    parser.add_option('-o', dest='outfile', default=None, help='Output file [default: %default]')
-    parser.add_option('-v', dest='verbose', default=False, help='Verbose mode [default: %default]', action='store_true')
-    parser.add_option('-s', dest='graphPaths', default=None, help='File containing paths to splice graphs to augment gene models')
+    parser = argparse.ArgumentParser(description='Generate GFF file for MISO of exon skipping events')
+    parser.add_argument('-m', dest='model', default=SG_GENE_MODEL, help='Gene model GFF file [default: %(default)s]')
+    parser.add_argument('-o', dest='outfile', default=None, help='Output file [default: %(default)s]')
+    parser.add_argument('-v', dest='verbose', default=False, help='Verbose mode [default: %(default)s]', action='store_true')
+    parser.add_argument('-s', dest='graphPaths', default=None, help='File containing paths to splice graphs to augment gene models')
     return parser
 
 
 def parse_args(argv=None):
     parser = build_parser()
-    opts, args = parser.parse_args(argv)
+    opts = parser.parse_args(argv)
     errStrings = []
     if not opts.model:
         errStrings.append('** No GFF gene model specified.  Set SPLICEGRAPHER_GENE_MODEL or use the -m option.')
@@ -30,7 +30,7 @@ def parse_args(argv=None):
         parser.print_help()
         sys.stderr.write('\n%s\n' % '\n'.join(errStrings))
         raise SystemExit(1)
-    return opts, args
+    return opts, []
 
 def getEventLocs( node ):
     if node.strand == '+':
@@ -153,5 +153,4 @@ def main(argv=None):
 
 if __name__ == '__main__':
     raise SystemExit(main())
-
 

--- a/scripts/simulate_IR.py
+++ b/scripts/simulate_IR.py
@@ -32,10 +32,10 @@ from iDiffIR.SpliceGrapher.formats.fasta       import FastaRecord
 
 from iDiffIR.SpliceGrapher.formats.loader import loadGeneModels
 
-from optparse import OptionParser
+import argparse
 import os, sys, warnings, numpy, itertools, random, math
 
-USAGE="""%prog [options]
+USAGE="""%(prog)s [options]
 
 """
 
@@ -49,29 +49,29 @@ diffGenes = []
 
 
 def build_parser():
-    parser = OptionParser(usage=USAGE)
-    parser.add_option('-f', dest='fasta',    default=SG_FASTA_REF,  help='FASTA reference file [default: %default]')
-    parser.add_option('-m', dest='model',    default=SG_GENE_MODEL, help='Gene model GFF file [default: %default]')
-    parser.add_option('-n', dest='qname',    default='DISimulator', help='QNAME for read alignment records [default: %default]')
-    parser.add_option('-o', dest='outfile',  default=None,          help='Output file [default: %default]')
-    parser.add_option('-g', dest='diffGExp', default=0.25, type=float, help='Frequency of differential gene expression [default: %default]')
-    parser.add_option('-i', dest='diffIExp', default=0.10, type=float, help='Frequency of differential isoform expression [default: %default]')
-    parser.add_option('-D', dest='diffIso', default=2.0, type=float, help='Relative differential isoform expression')
-    parser.add_option('-l', dest='read_length', default=80, type=int, help='Length of simulated reads [default: %default]')
-    parser.add_option('-a', dest='minAnchor', default=8, type=int, help='Minimum anchor length for a spliced alignment [default: %default]')
-    parser.add_option('-t', dest='test', default=False, action='store_true', help='Run test [default: %default]')
-    parser.add_option('-v', dest='verbose',  default=False,         help='Verbose mode [default: %default]', action='store_true')
-    parser.add_option('-d', dest='depth', default=50, type=int, help='Depth of up-regulated and equal expression')
-    parser.add_option('-e', dest='expfile', default=None, type=str, help='path of expression file')
-    parser.add_option('-s', dest='summary_file', default='summary.txt', type=str, help='name of summary file')
-    parser.add_option('-r', dest='reps', default=1, type=int, help='number of replicates for each condition')
-    parser.add_option('-p', dest='procs', default=1, type=int, help='number of processors to use for sorting sam files')
+    parser = argparse.ArgumentParser(usage=USAGE)
+    parser.add_argument('-f', dest='fasta', default=SG_FASTA_REF, help='FASTA reference file [default: %(default)s]')
+    parser.add_argument('-m', dest='model', default=SG_GENE_MODEL, help='Gene model GFF file [default: %(default)s]')
+    parser.add_argument('-n', dest='qname', default='DISimulator', help='QNAME for read alignment records [default: %(default)s]')
+    parser.add_argument('-o', dest='outfile', default=None, help='Output file [default: %(default)s]')
+    parser.add_argument('-g', dest='diffGExp', default=0.25, type=float, help='Frequency of differential gene expression [default: %(default)s]')
+    parser.add_argument('-i', dest='diffIExp', default=0.10, type=float, help='Frequency of differential isoform expression [default: %(default)s]')
+    parser.add_argument('-D', dest='diffIso', default=2.0, type=float, help='Relative differential isoform expression')
+    parser.add_argument('-l', dest='read_length', default=80, type=int, help='Length of simulated reads [default: %(default)s]')
+    parser.add_argument('-a', dest='minAnchor', default=8, type=int, help='Minimum anchor length for a spliced alignment [default: %(default)s]')
+    parser.add_argument('-t', dest='test', default=False, action='store_true', help='Run test [default: %(default)s]')
+    parser.add_argument('-v', dest='verbose', default=False, help='Verbose mode [default: %(default)s]', action='store_true')
+    parser.add_argument('-d', dest='depth', default=50, type=int, help='Depth of up-regulated and equal expression')
+    parser.add_argument('-e', dest='expfile', default=None, type=str, help='path of expression file')
+    parser.add_argument('-s', dest='summary_file', default='summary.txt', type=str, help='name of summary file')
+    parser.add_argument('-r', dest='reps', default=1, type=int, help='number of replicates for each condition')
+    parser.add_argument('-p', dest='procs', default=1, type=int, help='number of processors to use for sorting sam files')
     return parser
 
 
 def parse_args(argv=None):
     parser = build_parser()
-    parsed_opts, args = parser.parse_args(argv)
+    parsed_opts = parser.parse_args(argv)
     errStrings = []
     if not parsed_opts.model:
         errStrings.append('** No GFF gene model specified.  Set SPLICEGRAPHER_GENE_MODEL or use the -m option.')
@@ -81,7 +81,7 @@ def parse_args(argv=None):
         parser.print_help()
         sys.stderr.write('\n%s\n' % '\n'.join(errStrings))
         raise SystemExit(1)
-    return parsed_opts, args
+    return parsed_opts, []
 
 
 def initialize_state(argv=None):

--- a/tests/test_argparse_migration.py
+++ b/tests/test_argparse_migration.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TARGET_SCRIPTS = [
+    "scripts/make_MISO_AS_GFF.py",
+    "scripts/make_MISO_IR_GFF.py",
+    "scripts/make_MISO_SE_GFF.py",
+    "scripts/simulate_IR.py",
+]
+
+
+def test_target_scripts_use_argparse_only():
+    for script in TARGET_SCRIPTS:
+        content = (ROOT / script).read_text(encoding="utf-8")
+        assert "optparse" not in content
+        assert "argparse" in content


### PR DESCRIPTION
## Summary
- migrate `scripts/make_MISO_AS_GFF.py` from `optparse` to `argparse`
- migrate `scripts/make_MISO_IR_GFF.py` from `optparse` to `argparse`
- migrate `scripts/make_MISO_SE_GFF.py` and `scripts/simulate_IR.py` from `optparse` to `argparse`
- add `tests/test_argparse_migration.py` to lock in argparse usage for these scripts

## Testing
- `uv run pytest -q`
- `uv run python scripts/make_MISO_AS_GFF.py --help`
- `uv run python scripts/make_MISO_IR_GFF.py --help`
- `uv run python scripts/make_MISO_SE_GFF.py --help`
- `uv run python scripts/simulate_IR.py --help`

Closes #12
