### PR TITLE
refactor(cli): migrate SpliceGrapher batch C to argparse

### DIFF
--- a/iDiffIR/SpliceGrapher/scripts/generate_splice_site_data.py
+++ b/iDiffIR/SpliceGrapher/scripts/generate_splice_site_data.py
@@ -29,7 +29,7 @@ from iDiffIR.SpliceGrapher.formats.FastaLoader import FastaLoader
 from iDiffIR.SpliceGrapher.formats.loader      import *
 from iDiffIR.SpliceGrapher.SpliceGraph         import *
 
-from optparse import OptionParser, OptionGroup
+import argparse
 from glob     import glob
 from sys import maxsize as MAXINT
 import os, random, sys, warnings
@@ -123,38 +123,40 @@ def writeReport(options, jctDict) :
 # How far to extend sequences around splice sites:
 WINDOW_SIZE = 50
 
-USAGE="""%prog [options]"""
+USAGE="""%(prog)s [options]"""
 
 DESCR="""Generates positive or negative examples of splice sites based on
 an organism's GFF gene model annotations or a set of splice graphs, and its
 FASTA reference sequences.  Default splice site type is 'donor' and the
 default dimer is 'GT'."""
 
-parser = OptionParser(usage=USAGE, description=DESCR)
-required = OptionGroup(parser, 'Required', "Note: use a gene model (-m), a list of splice graphs (-S), or both, but at least one is required.  A FASTA reference is always required.")
-required.add_option('-f', dest='fasta',        default=SG_FASTA_REF,  help='(Required) FASTA reference file [default: %default]')
-required.add_option('-m', dest='model',        default=SG_GENE_MODEL, help='GFF gene model file [default: %default]')
-required.add_option('-S', dest='splicegraphs', default=None,          help='File containing a list of splice graph file paths [default: %default]')
-parser.add_option_group(required)
-
-optional = OptionGroup(parser, 'Other')
-optional.add_option('-a', dest='acceptor',     default=False,         help='Look for dimer in acceptor sites [default: %default]', action='store_true')
-optional.add_option('-D', dest='add_dimer',    default=False,         help='Include dimer in sequence output [default: %default]', action='store_true')
-optional.add_option('-d', dest='dimers',       default='GT',          help='Dimers to look for [default: %default]')
-optional.add_option('-i', dest='minintron',    default=4,             help='Minimum allowed intron length [default: all]', type='int')
-optional.add_option('-n', dest='limit',        default=0,             help='Generate given number of examples [default: all]', type='int')
-optional.add_option('-W', dest='window',       default=WINDOW_SIZE,   help='Set window size on either side of splice site [default: %default]', type='int')
-optional.add_option('-o', dest='outfile',      default=None,          help='Output file [default: %default]')
-optional.add_option('-r', dest='report',       default=None ,         help='Produce splice site frequency report [default: %default]')
-optional.add_option('-N', dest='negative',     default=False,         help='Generate negative examples [default: %default]', action='store_true')
-optional.add_option('-v', dest='verbose',      default=False,         help='Verbose mode [default: %default]', action='store_true')
-parser.add_option_group(optional)
-
+parser = argparse.ArgumentParser(usage=USAGE, description=DESCR)
+required = parser.add_argument_group('Required', "Note: use a gene model (-m), a list of splice graphs (-S), or both, but at least one is required.  A FASTA reference is always required.")
+required.add_argument('-f', dest='fasta',        default=SG_FASTA_REF,  help='(Required) FASTA reference file [default: %(default)s]')
+required.add_argument('-m', dest='model',        default=SG_GENE_MODEL, help='GFF gene model file [default: %(default)s]')
+required.add_argument('-S', dest='splicegraphs', default=None,          help='File containing a list of splice graph file paths [default: %(default)s]')
+optional = parser.add_argument_group('Other')
+optional.add_argument('-a', dest='acceptor',     default=False,         help='Look for dimer in acceptor sites [default: %(default)s]', action='store_true')
+optional.add_argument('-D', dest='add_dimer',    default=False,         help='Include dimer in sequence output [default: %(default)s]', action='store_true')
+optional.add_argument('-d', dest='dimers',       default='GT',          help='Dimers to look for [default: %(default)s]')
+optional.add_argument('-i', dest='minintron',    default=4,             help='Minimum allowed intron length [default: all]', type=int)
+optional.add_argument('-n', dest='limit',        default=0,             help='Generate given number of examples [default: all]', type=int)
+optional.add_argument('-W', dest='window',       default=WINDOW_SIZE,   help='Set window size on either side of splice site [default: %(default)s]', type=int)
+optional.add_argument('-o', dest='outfile',      default=None,          help='Output file [default: %(default)s]')
+optional.add_argument('-r', dest='report',       default=None ,         help='Produce splice site frequency report [default: %(default)s]')
+optional.add_argument('-N', dest='negative',     default=False,         help='Generate negative examples [default: %(default)s]', action='store_true')
+optional.add_argument('-v', dest='verbose',      default=False,         help='Verbose mode [default: %(default)s]', action='store_true')
 #-------------------------------------------------------
 # Main program
 #-------------------------------------------------------
-opts, args = parser.parse_args(sys.argv[1:])
+def _parse_opts_and_args(parser, argv):
+    parser.add_argument('args', nargs='*')
+    opts = parser.parse_args(argv)
+    args = opts.args
+    delattr(opts, 'args')
+    return opts, args
 
+opts, args = _parse_opts_and_args(parser, sys.argv[1:])
 errStrings = []
 if not (opts.model or opts.splicegraphs) :
     errStrings.append('** No GFF gene model or splice graphs specified.  Use the -m or -S option, or set SG_GENE_MODEL in your SpliceGrapher configuration.')

--- a/iDiffIR/SpliceGrapher/scripts/isolasso_pipeline.py
+++ b/iDiffIR/SpliceGrapher/scripts/isolasso_pipeline.py
@@ -24,7 +24,7 @@ from iDiffIR.SpliceGrapher.shared.config import *
 from iDiffIR.SpliceGrapher.shared.utils  import *
 from iDiffIR.SpliceGrapher.formats.fasta import *
 
-from optparse import OptionParser
+import argparse
 from glob import glob
 import os,sys,subprocess
 
@@ -82,7 +82,7 @@ def checkIsoLassoValues(isoFile) :
 
     return 'range of FPKM values was %.3f to %.3f\n' % (min(fpkmVals), max(fpkmVals))
 
-USAGE = """%prog graph-files SAM-file [options]
+USAGE = """%(prog)s graph-files SAM-file [options]
 
 Where:
     graph-files    is either a file of paths to splice graph files
@@ -91,21 +91,27 @@ Where:
     SAM-file       is a SAM file to be used with IsoLasso
 
 Example:
-    %prog my_predictions filtered.sam
+    %(prog)s my_predictions filtered.sam
 
 Runs the IsoLasso software (Li et al., 2011) using SpliceGrapher predictions as a reference."""
 
 # Establish command-line options:
-parser = OptionParser(usage=USAGE)
-parser.add_option('-C', dest='cem',       default=False,  help='Use CEM instead of LASSO [default: %default]', action='store_true')
-parser.add_option('-d', dest='outdir',    default='isolasso', help='Output directory [default: %default]')
-parser.add_option('-p', dest='params',    default='',     help='Additional parameters for IsoLasso [default: %default]')
-parser.add_option('-f', dest='fasta',     default=SG_FASTA_REF, help='FASTA genome reference [default: %default]')
-parser.add_option('-t', dest='threshold', default=1.0,    help='Minimum FPKM threshold [default: %default]', type='float')
-parser.add_option('-U', dest='unresolved',default=False,  help='Include unresolved transcripts [default: %default]', action='store_true')
-parser.add_option('-v', dest='verbose',   default=False,  help='Verbose mode [default: %default]', action='store_true')
-opts, args = parser.parse_args(sys.argv[1:])
+parser = argparse.ArgumentParser(usage=USAGE)
+parser.add_argument('-C', dest='cem',       default=False,  help='Use CEM instead of LASSO [default: %(default)s]', action='store_true')
+parser.add_argument('-d', dest='outdir',    default='isolasso', help='Output directory [default: %(default)s]')
+parser.add_argument('-p', dest='params',    default='',     help='Additional parameters for IsoLasso [default: %(default)s]')
+parser.add_argument('-f', dest='fasta',     default=SG_FASTA_REF, help='FASTA genome reference [default: %(default)s]')
+parser.add_argument('-t', dest='threshold', default=1.0,    help='Minimum FPKM threshold [default: %(default)s]', type=float)
+parser.add_argument('-U', dest='unresolved',default=False,  help='Include unresolved transcripts [default: %(default)s]', action='store_true')
+parser.add_argument('-v', dest='verbose',   default=False,  help='Verbose mode [default: %(default)s]', action='store_true')
+def _parse_opts_and_args(parser, argv):
+    parser.add_argument('args', nargs='*')
+    opts = parser.parse_args(argv)
+    args = opts.args
+    delattr(opts, 'args')
+    return opts, args
 
+opts, args = _parse_opts_and_args(parser, sys.argv[1:])
 #-------------------------------------------------------------------------------------------------
 # Parse the command line and make sure everything looks OK
 MIN_ARGS = 2

--- a/iDiffIR/SpliceGrapher/scripts/isolasso_update_graphs.py
+++ b/iDiffIR/SpliceGrapher/scripts/isolasso_update_graphs.py
@@ -20,7 +20,7 @@ from iDiffIR.SpliceGrapher.shared.utils import *
 from iDiffIR.SpliceGrapher.formats.sam  import *
 from iDiffIR.SpliceGrapher.formats.FastaLoader  import *
 from iDiffIR.SpliceGrapher.SpliceGraph  import *
-from optparse                   import OptionParser
+import argparse
 import os,sys
 
 # IsoLasso GTF example (last field only):
@@ -44,17 +44,23 @@ def attributeDict(line) :
         result[key] = val
     return result
 
-USAGE = """%prog graph-list transcript-map IsoLasso-GTF [options]
+USAGE = """%(prog)s graph-list transcript-map IsoLasso-GTF [options]
 
 Updates SpliceGrapher predictions using transcripts confirmed by IsoLasso."""
 
 # Establish command-line options:
-parser = OptionParser(usage=USAGE)
-parser.add_option('-d', dest='outdir',    default='.',  help='Top-level output directory [default: %default]')
-parser.add_option('-t', dest='threshold', default=1.0,  help='FPKM minimum threshold [default: %default]', type='float')
-parser.add_option('-v', dest='verbose',   default=False,help='Verbose mode [default: %default]', action='store_true')
-opts, args = parser.parse_args(sys.argv[1:])
+parser = argparse.ArgumentParser(usage=USAGE)
+parser.add_argument('-d', dest='outdir',    default='.',  help='Top-level output directory [default: %(default)s]')
+parser.add_argument('-t', dest='threshold', default=1.0,  help='FPKM minimum threshold [default: %(default)s]', type=float)
+parser.add_argument('-v', dest='verbose',   default=False,help='Verbose mode [default: %(default)s]', action='store_true')
+def _parse_opts_and_args(parser, argv):
+    parser.add_argument('args', nargs='*')
+    opts = parser.parse_args(argv)
+    args = opts.args
+    delattr(opts, 'args')
+    return opts, args
 
+opts, args = _parse_opts_and_args(parser, sys.argv[1:])
 if len(args) != 3 :
     parser.print_help()
     sys.exit(1)

--- a/iDiffIR/SpliceGrapher/scripts/psginfer_pipeline.py
+++ b/iDiffIR/SpliceGrapher/scripts/psginfer_pipeline.py
@@ -24,7 +24,7 @@ from iDiffIR.SpliceGrapher.shared.config import *
 from iDiffIR.SpliceGrapher.shared.utils  import *
 from iDiffIR.SpliceGrapher.formats.fasta import *
 
-from optparse import OptionParser
+import argparse
 from glob import glob
 import os,sys,subprocess
 
@@ -56,24 +56,30 @@ RESULTS_DIR      = 'putative_forms_psg_results'
 PRED_DIR         = 'psgpred'
 ISOFORM_RESULTS  = 'isoform.results.txt'
 
-USAGE = """%prog graph-list fastq1 fastq2 [options]
+USAGE = """%(prog)s graph-list fastq1 fastq2 [options]
 
 Example:
-    %prog initial_predictions.lis reads_1.fq reads_2.fq
+    %(prog)s initial_predictions.lis reads_1.fq reads_2.fq
 
 Runs the PSGInfer software (Dewey et al., 2010) using SpliceGrapher
 predictions as a reference."""
 
 # Establish command-line options:
-parser = OptionParser(usage=USAGE)
-parser.add_option('-d', dest='outdir',  default='.',          help='Output directory [default: %default]')
-parser.add_option('-D', dest='debug',   default=False,        help='Debug mode (just show commands) [default: %default]', action='store_true')
-parser.add_option('-f', dest='fasta',   default=SG_FASTA_REF, help='Genome reference FASTA [default: %default]')
-parser.add_option('-l', dest='logfile', default=None,         help='Optional log file [default: %default]')
-parser.add_option('-t', dest='thresh',  default=DEFAULT_THRESH, help='Probability threshold [default: %default]', type='float')
-parser.add_option('-v', dest='verbose', default=False,        help='Verbose mode [default: %default]', action='store_true')
-opts, args = parser.parse_args(sys.argv[1:])
+parser = argparse.ArgumentParser(usage=USAGE)
+parser.add_argument('-d', dest='outdir',  default='.',          help='Output directory [default: %(default)s]')
+parser.add_argument('-D', dest='debug',   default=False,        help='Debug mode (just show commands) [default: %(default)s]', action='store_true')
+parser.add_argument('-f', dest='fasta',   default=SG_FASTA_REF, help='Genome reference FASTA [default: %(default)s]')
+parser.add_argument('-l', dest='logfile', default=None,         help='Optional log file [default: %(default)s]')
+parser.add_argument('-t', dest='thresh',  default=DEFAULT_THRESH, help='Probability threshold [default: %(default)s]', type=float)
+parser.add_argument('-v', dest='verbose', default=False,        help='Verbose mode [default: %(default)s]', action='store_true')
+def _parse_opts_and_args(parser, argv):
+    parser.add_argument('args', nargs='*')
+    opts = parser.parse_args(argv)
+    args = opts.args
+    delattr(opts, 'args')
+    return opts, args
 
+opts, args = _parse_opts_and_args(parser, sys.argv[1:])
 #-------------------------------------------------------------------------------------------------
 # Parse the command line and make sure everything looks OK
 MIN_ARGS = 3

--- a/iDiffIR/SpliceGrapher/scripts/psginfer_update_graphs.py
+++ b/iDiffIR/SpliceGrapher/scripts/psginfer_update_graphs.py
@@ -20,20 +20,26 @@ from iDiffIR.SpliceGrapher.shared.utils import *
 from iDiffIR.SpliceGrapher.formats.sam  import *
 from iDiffIR.SpliceGrapher.formats.FastaLoader  import *
 from iDiffIR.SpliceGrapher.SpliceGraph  import *
-from optparse                   import OptionParser
+import argparse
 import os,sys
 
-USAGE = """%prog graph-list transcript-map psginfer-isoform-table [options]
+USAGE = """%(prog)s graph-list transcript-map psginfer-isoform-table [options]
 
 Updates SpliceGrapher predictions using transcripts confirmed by psgInfer."""
 
 # Establish command-line options:
-parser = OptionParser(usage=USAGE)
-parser.add_option('-d', dest='outdir',    default='.',  help='Top-level output directory [default: %default]')
-parser.add_option('-t', dest='threshold', default=0.1,  help='Threshold for accepting isoforms (between 0 and 1)[default: %default]', type='float')
-parser.add_option('-v', dest='verbose',   default=False,help='Verbose mode [default: %default]', action='store_true')
-opts, args = parser.parse_args(sys.argv[1:])
+parser = argparse.ArgumentParser(usage=USAGE)
+parser.add_argument('-d', dest='outdir',    default='.',  help='Top-level output directory [default: %(default)s]')
+parser.add_argument('-t', dest='threshold', default=0.1,  help='Threshold for accepting isoforms (between 0 and 1)[default: %(default)s]', type=float)
+parser.add_argument('-v', dest='verbose',   default=False,help='Verbose mode [default: %(default)s]', action='store_true')
+def _parse_opts_and_args(parser, argv):
+    parser.add_argument('args', nargs='*')
+    opts = parser.parse_args(argv)
+    args = opts.args
+    delattr(opts, 'args')
+    return opts, args
 
+opts, args = _parse_opts_and_args(parser, sys.argv[1:])
 if len(args) != 3 :
     parser.print_help()
     sys.exit(1)

--- a/iDiffIR/SpliceGrapher/scripts/realignment_pipeline.py
+++ b/iDiffIR/SpliceGrapher/scripts/realignment_pipeline.py
@@ -24,7 +24,7 @@ from iDiffIR.SpliceGrapher.shared.config import *
 from iDiffIR.SpliceGrapher.shared.utils  import *
 from iDiffIR.SpliceGrapher.formats.fasta import *
 
-from optparse import OptionParser
+import argparse
 import os,sys,subprocess,multiprocessing
 
 GENE_MODEL_ERR = '** No gene models specified.  Use the -m option or set SG_GENE_MODEL in your SpliceGrapher configuration.'
@@ -73,17 +73,17 @@ def getReadLength(fqFile) :
             break
     return result
 
-USAGE = """%prog original-dir [options]
+USAGE = """%(prog)s original-dir [options]
 
 Where:
     original-dir = directory containing original predictions
                    created with predict_graphs.py
 
 Single-end read example:
-    %prog original_predictions -1 myreads.fq
+    %(prog)s original_predictions -1 myreads.fq
 
 Paired-end example:
-    %prog original_predictions -1 myreads_1.fq -2 myreads_2.fq
+    %(prog)s original_predictions -1 myreads_1.fq -2 myreads_2.fq
 
 Runs the realignment procedure to resolve exons in a set of splice graphs.
 First it generates putative transcripts, then uses BWA to align reads
@@ -91,17 +91,23 @@ to the putative transcripts, and places updated graphs in an output
 directory (local directory by default)."""
 
 # Establish command-line options:
-parser = OptionParser(usage=USAGE)
-parser.add_option('-1', dest='first',   default=None,
-        help='FASTQ file containing first half of mate pairs for paired-end reads, or the file containing single-end reads [default: %default]')
-parser.add_option('-2', dest='second',  default=None,
-        help='FASTQ file containing second half of mate pairs (paired-end reads only) [default: %default]')
-parser.add_option('-d', dest='outdir',  default='.',           help='Output directory [default: %default]')
-parser.add_option('-f', dest='fasta',   default=SG_FASTA_REF,  help='Genome reference file [default: %default]')
-parser.add_option('-m', dest='model',   default=SG_GENE_MODEL, help='Gene model annotations (GFF3/GTF) [default: %default]')
-parser.add_option('-v', dest='verbose', default=False,         help='Verbose mode [default: %default]', action='store_true')
-opts, args = parser.parse_args(sys.argv[1:])
+parser = argparse.ArgumentParser(usage=USAGE)
+parser.add_argument('-1', dest='first',   default=None,
+        help='FASTQ file containing first half of mate pairs for paired-end reads, or the file containing single-end reads [default: %(default)s]')
+parser.add_argument('-2', dest='second',  default=None,
+        help='FASTQ file containing second half of mate pairs (paired-end reads only) [default: %(default)s]')
+parser.add_argument('-d', dest='outdir',  default='.',           help='Output directory [default: %(default)s]')
+parser.add_argument('-f', dest='fasta',   default=SG_FASTA_REF,  help='Genome reference file [default: %(default)s]')
+parser.add_argument('-m', dest='model',   default=SG_GENE_MODEL, help='Gene model annotations (GFF3/GTF) [default: %(default)s]')
+parser.add_argument('-v', dest='verbose', default=False,         help='Verbose mode [default: %(default)s]', action='store_true')
+def _parse_opts_and_args(parser, argv):
+    parser.add_argument('args', nargs='*')
+    opts = parser.parse_args(argv)
+    args = opts.args
+    delattr(opts, 'args')
+    return opts, args
 
+opts, args = _parse_opts_and_args(parser, sys.argv[1:])
 #-------------------------------------------------------------------------------------------------
 # Parse the command line and make sure everything looks OK
 MIN_ARGS = 1

--- a/iDiffIR/SpliceGrapher/scripts/splice_junction_pipeline.py
+++ b/iDiffIR/SpliceGrapher/scripts/splice_junction_pipeline.py
@@ -23,7 +23,7 @@ sequences prior to running alignments.
 from iDiffIR.SpliceGrapher.shared.config import *
 from iDiffIR.SpliceGrapher.shared.utils  import *
 from iDiffIR.SpliceGrapher.formats.fasta import *
-from optparse                    import OptionParser
+import argparse
 import os,sys,subprocess
 
 LEGAL_DIMERS    = ['%s%s'%(a,b) for a in 'acgt' for b in 'acgt']
@@ -89,7 +89,7 @@ def selectModelParameters(dimer, trainingFile, opts, acceptor=False, logstream=N
         runCommand(command, logstream=logstream, debug=opts.debug, stderr=nullStream, stdout=nullStream)
     return dimerFile
 
-USAGE = """%prog [options]
+USAGE = """%(prog)s [options]
 
 Script for running the full splice junction prediction pipeline.
 This will perform the following steps:
@@ -101,21 +101,27 @@ This will perform the following steps:
        d. Use predicted sites to generate predicted junction sequences (--gendb option)"""
 
 # Establish command-line options:
-parser = OptionParser(usage=USAGE)
-parser.add_option('-a', dest='acceptors',  default=ACC_STRINGS,   help='Acceptor site dimers to predict [default: %default]')
-parser.add_option('-D', dest='debug',      default=False,         help="Show but don't run commands [default: %default]", action='store_true')
-parser.add_option('-d', dest='donors',     default=DON_STRINGS,   help='Donor site dimers to predict [default: %default]')
-parser.add_option('-f', dest='fasta',      default=SG_FASTA_REF,  help='Fasta reference file [default: %default]')
-parser.add_option('-m', dest='model',      default=SG_GENE_MODEL, help='Gene model annotations (GFF3) [default: %default]')
-parser.add_option('-l', dest='logfile',    default=None,          help='Optional log file [default: %default]')
-parser.add_option('-o', dest='overlap',    default=10,            help='Required overlap on either side of a junction [default: %default]', type='int')
-parser.add_option('-O', dest='overwrite',  default=False,         help='Over-write any existing files [default: %default]', action='store_true')
-parser.add_option('-r', dest='readlen',    default=36,            help='Read length [default: %default]', type='int')
-parser.add_option('-t', dest='training',   default=1000,          help='Training data set size [default: %default]', type='int')
-parser.add_option('-v', dest='verbose',    default=False,         help='Verbose mode [default: %default]', action='store_true')
-parser.add_option('--gendb', dest='gendb', default=False,         help="Use predicted splice sites to generate splice junction sequence database (can take a long time) [default: %default]", action='store_true')
-opts, args = parser.parse_args(sys.argv[1:])
+parser = argparse.ArgumentParser(usage=USAGE)
+parser.add_argument('-a', dest='acceptors',  default=ACC_STRINGS,   help='Acceptor site dimers to predict [default: %(default)s]')
+parser.add_argument('-D', dest='debug',      default=False,         help="Show but don't run commands [default: %(default)s]", action='store_true')
+parser.add_argument('-d', dest='donors',     default=DON_STRINGS,   help='Donor site dimers to predict [default: %(default)s]')
+parser.add_argument('-f', dest='fasta',      default=SG_FASTA_REF,  help='Fasta reference file [default: %(default)s]')
+parser.add_argument('-m', dest='model',      default=SG_GENE_MODEL, help='Gene model annotations (GFF3) [default: %(default)s]')
+parser.add_argument('-l', dest='logfile',    default=None,          help='Optional log file [default: %(default)s]')
+parser.add_argument('-o', dest='overlap',    default=10,            help='Required overlap on either side of a junction [default: %(default)s]', type=int)
+parser.add_argument('-O', dest='overwrite',  default=False,         help='Over-write any existing files [default: %(default)s]', action='store_true')
+parser.add_argument('-r', dest='readlen',    default=36,            help='Read length [default: %(default)s]', type=int)
+parser.add_argument('-t', dest='training',   default=1000,          help='Training data set size [default: %(default)s]', type=int)
+parser.add_argument('-v', dest='verbose',    default=False,         help='Verbose mode [default: %(default)s]', action='store_true')
+parser.add_argument('--gendb', dest='gendb', default=False,         help="Use predicted splice sites to generate splice junction sequence database (can take a long time) [default: %(default)s]", action='store_true')
+def _parse_opts_and_args(parser, argv):
+    parser.add_argument('args', nargs='*')
+    opts = parser.parse_args(argv)
+    args = opts.args
+    delattr(opts, 'args')
+    return opts, args
 
+opts, args = _parse_opts_and_args(parser, sys.argv[1:])
 #-------------------------------------------------------------------------------------------------
 # Parse the command line and make sure everything looks OK
 errStrings = []

--- a/iDiffIR/SpliceGrapher/scripts/view_splicegraph_multiplot.py
+++ b/iDiffIR/SpliceGrapher/scripts/view_splicegraph_multiplot.py
@@ -34,7 +34,7 @@ from iDiffIR.SpliceGrapher.formats.sam               import *
 from iDiffIR.SpliceGrapher                           import SpliceGraph
 from iDiffIR.SpliceGrapher.formats                   import gtf, wig, bed, xydata
 
-from optparse import OptionParser, OptionGroup
+import argparse
 
 import sys, os
 
@@ -78,53 +78,56 @@ X_PAD_FRACTION  = 0.01
 #==========================================================================
 # Main program
 #==========================================================================
-USAGE = """%prog [options] gene-name
+USAGE = """%(prog)s [options] gene-name
 
 Interface for viewing alternative splicing information for a gene."""
 
 #==========================================================================
 # Initialize command-line options:
-parser = OptionParser(usage=USAGE)
-parser.add_option('-v', dest='verbose',      default=False,       action='store_true', help='use verbose output [default: %default]')
+parser = argparse.ArgumentParser(usage=USAGE)
+parser.add_argument('-v', dest='verbose',      default=False,       action='store_true', help='use verbose output [default: %(default)s]')
 
-fileGroup  = OptionGroup(parser, 'File Options')
-fileGroup.add_option('-m', dest='model',        default=SG_GENE_MODEL, help='GFF gene model reference [default: %default]')
-fileGroup.add_option('-o', dest='output',       default=None,          help='Output file (extension determines format) [default: screen]')
-fileGroup.add_option('-d', dest='depth_file',   default=None,          help='SAM alignment file (gapped and spliced reads) [default: %default]')
-fileGroup.add_option('-s', dest='splice_graph', default=None,          help='GFF splice graph file [default: %default]')
-fileGroup.add_option('-G', dest='orig_graph',   default=None,          help='Baseline graph file [default: none]')
-fileGroup.add_option('-X', dest='xydata',       default=None,          help='File of X,Y value pairs for X-Y plot [default: %default]')
-parser.add_option_group(fileGroup)
-
-displayGroup = OptionGroup(parser, 'Display Options')
-displayGroup.add_option('-c', dest='jctcover', default=False, help='Display read coverage on junctions [default: %default]', action='store_true')
-displayGroup.add_option('-x', dest='xLabels',  default=False, help='Add genomic position labels to plots [default: %default]', action='store_true')
-displayGroup.add_option('-E', dest='edge',     default=2,     help='Minimum edge thickness [default: %default]', type='int')
-displayGroup.add_option('-J', dest='minjct',   default=2,     help='Minimum coverage for displaying junctions [default: %default]', type='int')
-displayGroup.add_option('-L', dest='legend',   default=False, help='Add legend to graph [default: %default]', action='store_true')
-displayGroup.add_option('-H', dest='height',   default=8.5,   help='Display window height (inches) [default: %default]', type='float')
-displayGroup.add_option('-W', dest='width',    default=11,    help='Display window width (inches) [default: %default]', type='float')
-displayGroup.add_option('-F', dest='fontsize', default=12,    help='Font size for plot titles [default: %default]', type='int')
-displayGroup.add_option('-S', dest='shrink',   default=False, help='Shrink introns relative to exons [default: %default]', action='store_true')
-displayGroup.add_option('-D', dest='display',  default='OPJR',
-        help="Display order string for plots (O=original model, P=predicted graph, J=splice junctions, R=read depth, X=XY graph).  Examples: 'OPR', 'RJP' [default: '%default']")
-parser.add_option_group(displayGroup)
-
+fileGroup = parser.add_argument_group('File Options')
+fileGroup.add_argument('-m', dest='model',        default=SG_GENE_MODEL, help='GFF gene model reference [default: %(default)s]')
+fileGroup.add_argument('-o', dest='output',       default=None,          help='Output file (extension determines format) [default: screen]')
+fileGroup.add_argument('-d', dest='depth_file',   default=None,          help='SAM alignment file (gapped and spliced reads) [default: %(default)s]')
+fileGroup.add_argument('-s', dest='splice_graph', default=None,          help='GFF splice graph file [default: %(default)s]')
+fileGroup.add_argument('-G', dest='orig_graph',   default=None,          help='Baseline graph file [default: none]')
+fileGroup.add_argument('-X', dest='xydata',       default=None,          help='File of X,Y value pairs for X-Y plot [default: %(default)s]')
+displayGroup = parser.add_argument_group('Display Options')
+displayGroup.add_argument('-c', dest='jctcover', default=False, help='Display read coverage on junctions [default: %(default)s]', action='store_true')
+displayGroup.add_argument('-x', dest='xLabels',  default=False, help='Add genomic position labels to plots [default: %(default)s]', action='store_true')
+displayGroup.add_argument('-E', dest='edge',     default=2,     help='Minimum edge thickness [default: %(default)s]', type=int)
+displayGroup.add_argument('-J', dest='minjct',   default=2,     help='Minimum coverage for displaying junctions [default: %(default)s]', type=int)
+displayGroup.add_argument('-L', dest='legend',   default=False, help='Add legend to graph [default: %(default)s]', action='store_true')
+displayGroup.add_argument('-H', dest='height',   default=8.5,   help='Display window height (inches) [default: %(default)s]', type=float)
+displayGroup.add_argument('-W', dest='width',    default=11,    help='Display window width (inches) [default: %(default)s]', type=float)
+displayGroup.add_argument('-F', dest='fontsize', default=12,    help='Font size for plot titles [default: %(default)s]', type=int)
+displayGroup.add_argument('-S', dest='shrink',   default=False, help='Shrink introns relative to exons [default: %(default)s]', action='store_true')
+displayGroup.add_argument('-D', dest='display',  default='OPJR',
+        help="Display order string for plots (O=original model, P=predicted graph, J=splice junctions, R=read depth, X=XY graph).  Examples: 'OPR', 'RJP' [default: '%(default)s']")
 # Deprecated to simplify interface:
-## fileGroup.add_option('-b', dest='bed_file',     default=None,          help='BED predicted junctions file [default: %default]')
-## fileGroup.add_option('-j', dest='junctions',    default=None,          help='SAM spliced alignment file (spliced reads only) [default: %default]')
-## fileGroup.add_option('-t', dest='gtf_file',     default=None,          help='GTF file [default: %default]')
-## fileGroup.add_option('-w', dest='wig_file',     default=None,          help='WIG depth file [default: %default]')
-## displayGroup.add_option('-l', dest='labels',   default=False, help='Include exon labels [default: %default]', action='store_true')
-## displayGroup.add_option('-A', dest='adjust',   default=False, help='Adjust splice graph to match gene boundaries [default: %default]', action='store_true')
-## displayGroup.add_option('-U', dest='urmargin', default=0,     help='Margin for subsuming unresolved node into known exons [default: %default]', type='int')
-## displayGroup.add_option('-C', dest='clusters', default=False, help='Show read clusters instead of read depths [default: %default]', action='store_true')
-## displayGroup.add_option('-T', dest='threshold',default=1,     help='Minimum threshold for clusters (-C option) [default: %default]', type='int')
-## displayGroup.add_option('--titles', dest='titles',   default=None,  help='Alternate title for each display [default: %default]')
+## fileGroup.add_argument('-b', dest='bed_file',     default=None,          help='BED predicted junctions file [default: %(default)s]')
+## fileGroup.add_argument('-j', dest='junctions',    default=None,          help='SAM spliced alignment file (spliced reads only) [default: %(default)s]')
+## fileGroup.add_argument('-t', dest='gtf_file',     default=None,          help='GTF file [default: %(default)s]')
+## fileGroup.add_argument('-w', dest='wig_file',     default=None,          help='WIG depth file [default: %(default)s]')
+## displayGroup.add_argument('-l', dest='labels',   default=False, help='Include exon labels [default: %(default)s]', action='store_true')
+## displayGroup.add_argument('-A', dest='adjust',   default=False, help='Adjust splice graph to match gene boundaries [default: %(default)s]', action='store_true')
+## displayGroup.add_argument('-U', dest='urmargin', default=0,     help='Margin for subsuming unresolved node into known exons [default: %(default)s]', type=int)
+## displayGroup.add_argument('-C', dest='clusters', default=False, help='Show read clusters instead of read depths [default: %(default)s]', action='store_true')
+## displayGroup.add_argument('-T', dest='threshold',default=1,     help='Minimum threshold for clusters (-C option) [default: %(default)s]', type=int)
+## displayGroup.add_argument('--titles', dest='titles',   default=None,  help='Alternate title for each display [default: %(default)s]')
 
 #==========================================================================
 # Process command-line options:
-opts, args   = parser.parse_args(sys.argv[1:])
+def _parse_opts_and_args(parser, argv):
+    parser.add_argument('args', nargs='*')
+    opts = parser.parse_args(argv)
+    args = opts.args
+    delattr(opts, 'args')
+    return opts, args
+
+opts, args = _parse_opts_and_args(parser, sys.argv[1:])
 opts.display = opts.display.upper()
 
 # Removed after version 0.1.0 to simplify interface:

--- a/iDiffIR/SpliceGrapher/scripts/view_splicegraphs.py
+++ b/iDiffIR/SpliceGrapher/scripts/view_splicegraphs.py
@@ -26,7 +26,7 @@ from iDiffIR.SpliceGrapher.shared.utils              import *
 from iDiffIR.SpliceGrapher.shared.GeneModelConverter import *
 
 from pylab      import *
-from optparse   import OptionParser, OptionGroup
+import argparse
 from sys import maxsize as MAXINT
 import sys, os
 
@@ -56,7 +56,7 @@ X_PAD_FRACTION = 0.01
 #==========================================================================
 # Main program
 #==========================================================================
-USAGE = """%prog [options] files-or-genes
+USAGE = """%(prog)s [options] files-or-genes
 
 Displays one or more splice graphs given a list of files or genes.  A name
 that is not a file is assumed to be a gene.  When gene names are given,
@@ -64,41 +64,47 @@ gene models must also be provided (using SG_GENE_MODEL or the -m option).
 
 Examples:
 
-    %prog gene_1.gff                    (plot a single graph file)
-    %prog gene*.gff                     (display all graphs in the local directory that begin with 'gene')
-    %prog AT1G01060 AT1G01260 AT1G01910 (plot several genes)
-    %prog AT1G01060 gene_[123].gff      (mixture of gene model graphs and splice graph files)
+    %(prog)s gene_1.gff                    (plot a single graph file)
+    %(prog)s gene*.gff                     (display all graphs in the local directory that begin with 'gene')
+    %(prog)s AT1G01060 AT1G01260 AT1G01910 (plot several genes)
+    %(prog)s AT1G01060 gene_[123].gff      (mixture of gene model graphs and splice graph files)
 
 For more than four graphs you may need to adjust the output height (-H)."""
 
 #==========================================================================
 # Initialize command-line options:
-parser = OptionParser(usage=USAGE)
-parser.add_option('-a', dest='annotate', default=False,         help='(Re)annotate graphs [default: %default]', action='store_true')
-parser.add_option('-m', dest='model',    default=SG_GENE_MODEL, help='GFF gene model reference [default: %default]')
-parser.add_option('-o', dest='output',   default=None,          help='Output file [default: screen]')
-parser.add_option('-x', dest='xLabel',   default=False,         help='Show genomic positions [default: %default]', action='store_true')
-parser.add_option('-v', dest='verbose',  default=False,         help='Use verbose output [default: %default]', action='store_true')
-parser.add_option('-E', dest='edge',     default=1,             help='Intron edge weight [default: %default]', type='int')
-parser.add_option('-L', dest='legend',   default=False,         help='Add legend to splice graph plot [default: %default]', action='store_true')
-parser.add_option('-F', dest='fontsize', default=12,            help='Font size for plot titles [default: %default]', type='int')
-parser.add_option('-H', dest='height',   default=8,             help='Display height, in inches [default: %default]', type='float')
-parser.add_option('-W', dest='width',    default=15,            help='Display width, in inches [default: %default]', type='float')
-parser.add_option('-S', dest='shrink',   default=False,         help='Shrink introns [default: %default]', action='store_true')
-parser.add_option('-X', dest='xrange',   default=False,         help='Use the same genomic position range for all plots [default: %default]', action='store_true')
+parser = argparse.ArgumentParser(usage=USAGE)
+parser.add_argument('-a', dest='annotate', default=False,         help='(Re)annotate graphs [default: %(default)s]', action='store_true')
+parser.add_argument('-m', dest='model',    default=SG_GENE_MODEL, help='GFF gene model reference [default: %(default)s]')
+parser.add_argument('-o', dest='output',   default=None,          help='Output file [default: screen]')
+parser.add_argument('-x', dest='xLabel',   default=False,         help='Show genomic positions [default: %(default)s]', action='store_true')
+parser.add_argument('-v', dest='verbose',  default=False,         help='Use verbose output [default: %(default)s]', action='store_true')
+parser.add_argument('-E', dest='edge',     default=1,             help='Intron edge weight [default: %(default)s]', type=int)
+parser.add_argument('-L', dest='legend',   default=False,         help='Add legend to splice graph plot [default: %(default)s]', action='store_true')
+parser.add_argument('-F', dest='fontsize', default=12,            help='Font size for plot titles [default: %(default)s]', type=int)
+parser.add_argument('-H', dest='height',   default=8,             help='Display height, in inches [default: %(default)s]', type=float)
+parser.add_argument('-W', dest='width',    default=15,            help='Display width, in inches [default: %(default)s]', type=float)
+parser.add_argument('-S', dest='shrink',   default=False,         help='Shrink introns [default: %(default)s]', action='store_true')
+parser.add_argument('-X', dest='xrange',   default=False,         help='Use the same genomic position range for all plots [default: %(default)s]', action='store_true')
 
 # Deprecated to simplify interface:
-#parser.add_option('-t', dest='titles',   default=None,          help='List of graph titles [default: %default]')
-#parser.add_option('-A', dest='adjust',   default=False,         help='Adjust graphs to match gene boundaries [default: %default]', action='store_true')
-#parser.add_option('-G', dest='grid',     default=False,         help='Add axis grids to plots [default: %default]', action='store_true')
-## parser.add_option('-U', dest='urmargin', default=0,             help='Margin for subsuming unresolved nodes into resolved exons [default: %default]', type='int')
-#parser.add_option('-l', dest='labels',   default=False,         help='Show exon labels on plots [default: %default]', action='store_true')
-#parser.add_option('--shrink-factor', dest='shrinkfactor', default=MIN_INTRON_SIZE, help='Factor for shrinking introns (-S option) [default: %default]', type='int')
+#parser.add_argument('-t', dest='titles',   default=None,          help='List of graph titles [default: %(default)s]')
+#parser.add_argument('-A', dest='adjust',   default=False,         help='Adjust graphs to match gene boundaries [default: %(default)s]', action='store_true')
+#parser.add_argument('-G', dest='grid',     default=False,         help='Add axis grids to plots [default: %(default)s]', action='store_true')
+## parser.add_argument('-U', dest='urmargin', default=0,             help='Margin for subsuming unresolved nodes into resolved exons [default: %(default)s]', type=int)
+#parser.add_argument('-l', dest='labels',   default=False,         help='Show exon labels on plots [default: %(default)s]', action='store_true')
+#parser.add_argument('--shrink-factor', dest='shrinkfactor', default=MIN_INTRON_SIZE, help='Factor for shrinking introns (-S option) [default: %(default)s]', type=int)
 
 #==========================================================================
 # Process command-line options:
-opts, args   = parser.parse_args(sys.argv[1:])
+def _parse_opts_and_args(parser, argv):
+    parser.add_argument('args', nargs='*')
+    opts = parser.parse_args(argv)
+    args = opts.args
+    delattr(opts, 'args')
+    return opts, args
 
+opts, args = _parse_opts_and_args(parser, sys.argv[1:])
 #----------------------------------
 # Deprecated to simplify interface:
 opts.adjust       = False

--- a/tests/test_smoke_cli.py
+++ b/tests/test_smoke_cli.py
@@ -7,6 +7,16 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = [
+    "iDiffIR/SpliceGrapher/scripts/generate_splice_site_data.py",
+    "iDiffIR/SpliceGrapher/scripts/isolasso_pipeline.py",
+    "iDiffIR/SpliceGrapher/scripts/isolasso_update_graphs.py",
+    "iDiffIR/SpliceGrapher/scripts/psginfer_pipeline.py",
+    "iDiffIR/SpliceGrapher/scripts/psginfer_update_graphs.py",
+    "iDiffIR/SpliceGrapher/scripts/realignment_pipeline.py",
+    "iDiffIR/SpliceGrapher/scripts/sam_filter.py",
+    "iDiffIR/SpliceGrapher/scripts/splice_junction_pipeline.py",
+    "iDiffIR/SpliceGrapher/scripts/view_splicegraph_multiplot.py",
+    "iDiffIR/SpliceGrapher/scripts/view_splicegraphs.py",
     "scripts/convertSam.py",
     "scripts/getDepths.py",
     "scripts/get_gene_expression.py",


### PR DESCRIPTION
## Summary
- migrate Batch C SpliceGrapher scripts from `optparse` to `argparse`
- map `OptionGroup` usage to argparse argument groups where applicable
- preserve existing CLI flags/defaults and runtime behavior
- extend `tests/test_smoke_cli.py` with `--help` smoke coverage for Batch C scripts
- defer PyML-only imports in `sam_filter.py` so `--help` remains functional without PyML

## Scope
- `iDiffIR/SpliceGrapher/scripts/generate_splice_site_data.py`
- `iDiffIR/SpliceGrapher/scripts/view_splicegraphs.py`
- `iDiffIR/SpliceGrapher/scripts/view_splicegraph_multiplot.py`
- `iDiffIR/SpliceGrapher/scripts/isolasso_pipeline.py`
- `iDiffIR/SpliceGrapher/scripts/isolasso_update_graphs.py`
- `iDiffIR/SpliceGrapher/scripts/psginfer_pipeline.py`
- `iDiffIR/SpliceGrapher/scripts/psginfer_update_graphs.py`
- `iDiffIR/SpliceGrapher/scripts/realignment_pipeline.py`
- `iDiffIR/SpliceGrapher/scripts/splice_junction_pipeline.py`
- `iDiffIR/SpliceGrapher/scripts/sam_filter.py`

## Verification
- `uv run pytest -q` (`28 passed`)
- `uv run python -W error::SyntaxWarning -m compileall -f -q iDiffIR scripts tests`
- `uv run python <script> --help` for all Batch C scripts

Refs #14
Closes #17
