### PR TITLE
Issue A: Repair CI workflow for uv/pipless environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,13 @@ jobs:
         run: uv run python -W error::SyntaxWarning -m compileall -f -q iDiffIR scripts tests
 
       - name: Build wheel
-        run: uv run python -m pip install build && uv run python -m build
+        run: uv build --wheel
 
       - name: Validate wheel install
-        run: uv run python -m pip install --force-reinstall dist/*.whl
+        run: |
+          uv venv .wheel-venv --python ${{ matrix.python-version }}
+          uv pip install --python .wheel-venv/bin/python --force-reinstall dist/*.whl
+          .wheel-venv/bin/python -c "import iDiffIR"
 
       - name: Run tests
         run: uv run pytest

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_ci_workflow_does_not_use_python_m_pip():
+    ci_workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "python -m pip" not in ci_workflow
+


### PR DESCRIPTION
## Summary
- replace CI wheel build/install steps that depended on `python -m pip` with uv-native commands
- validate the built wheel in an isolated uv-created virtualenv and import `iDiffIR`
- add `tests/test_ci_workflow.py` to guard against reintroducing `python -m pip` in CI

## Test Plan
- uv run --python 3.12 pytest -q tests/test_ci_workflow.py
- uv run --python 3.12 pytest -q
- uv run --python 3.12 python -W error::SyntaxWarning -m compileall -f -q iDiffIR scripts tests
- uv build --wheel
- uv venv .wheel-venv --python 3.12
- uv pip install --python .wheel-venv/bin/python --force-reinstall dist/*.whl
- .wheel-venv/bin/python -c "import iDiffIR; print(iDiffIR.__version__)"

Closes #23
