### PR TITLE
Issue B: Unblock idiffir runtime on Python 3

### DIFF
--- a/iDiffIR/Plot.py
+++ b/iDiffIR/Plot.py
@@ -182,9 +182,14 @@ def writeGeneExpression( genes, odir ):
         for gene in genes:
             fout.write( '%s\t%f\t%f\t%f\n' % (gene.gid, gene.f1exp, gene.f2exp, gene.fc))
 
+
+def _union_len(collections):
+    return len(set.union(*collections)) if collections else 0
+
+
 def fullTexTable( summaryTable, odir=os.getcwd() ):
     handle = open( os.path.join(odir, 'dirTable.tex'), 'w' )
-    ks = sorted(summaryTable.keys())[:-2]
+    ks = sorted([key for key in summaryTable.keys() if type(key) == int])
     # upregulated
     handle.write('& Up')
     for key in ks:
@@ -193,7 +198,7 @@ def fullTexTable( summaryTable, odir=os.getcwd() ):
                                     len(summaryTable[key]['novel']['upirs']) ))
     k = [summaryTable[key]['known']['upirs'] for key in ks if type(key) == int]
     n = [summaryTable[key]['novel']['upirs'] for key in ks if type(key) == int]
-    handle.write( '& %d/%d' % (len( set.union(*k)), len( set.union(*n))) )
+    handle.write( '& %d/%d' % (_union_len(k), _union_len(n)) )
     handle.write('\\\\')
     handle.write('\n')
 
@@ -205,7 +210,7 @@ def fullTexTable( summaryTable, odir=os.getcwd() ):
                                     len(summaryTable[key]['novel']['downirs']) ))
     k = [summaryTable[key]['known']['downirs'] for key in ks if type(key) == int ]
     n = [summaryTable[key]['novel']['downirs'] for key in ks if type(key) == int ]
-    handle.write( '& %d/%d' % (len( set.union(*k)), len( set.union(*n))) )
+    handle.write( '& %d/%d' % (_union_len(k), _union_len(n)) )
     handle.write('\\\\')
     handle.write('\n')
 
@@ -218,7 +223,7 @@ def fullTexTable( summaryTable, odir=os.getcwd() ):
 
     k = [summaryTable[key]['known']['downirs'] for key in ks if type(key) == int]+[summaryTable[key]['known']['upirs'] for key in ks if type(key) == int]
     n = [summaryTable[key]['novel']['downirs'] for key in ks if type(key) == int]+[summaryTable[key]['novel']['upirs'] for key in ks if type(key) == int]
-    handle.write( '& %d/%d' % (len( set.union(*k)), len( set.union(*n))) )
+    handle.write( '& %d/%d' % (_union_len(k), _union_len(n)) )
     handle.write('\\\\')
     handle.write('\n')
 
@@ -230,7 +235,7 @@ def fullTexTable( summaryTable, odir=os.getcwd() ):
     k = [summaryTable[key]['known']['upgenes'] for key in ks]
     n = [summaryTable[key]['novel']['upgenes'] for key in ks]
 
-    handle.write( '& %d/%d' % (len( set.union(*k)), len( set.union(*n))) )
+    handle.write( '& %d/%d' % (_union_len(k), _union_len(n)) )
     handle.write('\\\\')
     handle.write('\n')
 
@@ -241,7 +246,7 @@ def fullTexTable( summaryTable, odir=os.getcwd() ):
                                     len(summaryTable[key]['novel']['downgenes']) ))
     k = [summaryTable[key]['known']['downgenes'] for key in ks]
     n = [summaryTable[key]['novel']['downgenes'] for key in ks]
-    handle.write( '& %d/%d' % (len( set.union(*k)), len( set.union(*n))) )
+    handle.write( '& %d/%d' % (_union_len(k), _union_len(n)) )
     handle.write('\\\\')
     handle.write('\n')
 
@@ -252,14 +257,14 @@ def fullTexTable( summaryTable, odir=os.getcwd() ):
                                     len(summaryTable[key]['novel']['downgenes'])+len(summaryTable[key]['novel']['upgenes']) ))
     k = [summaryTable[key]['known']['downgenes'] for key in ks]+[summaryTable[key]['known']['upgenes'] for key in ks]
     n = [summaryTable[key]['novel']['downgenes'] for key in ks]+[summaryTable[key]['novel']['upgenes'] for key in ks]
-    handle.write( '& %d/%d' % (len( set.union(*k)), len( set.union(*n))) )
+    handle.write( '& %d/%d' % (_union_len(k), _union_len(n)) )
     handle.write('\\\\')
     handle.write('\n')
 
 
 def fullTexTableSE( summaryTable, odir=os.getcwd() ):
     handle = open( os.path.join(odir, 'dirTableSE.tex'), 'w' )
-    ks = sorted(summaryTable.keys())[:-1]
+    ks = sorted([key for key in summaryTable.keys() if type(key) == int])
     # upregulated
     handle.write('& Up')
     for key in ks:
@@ -268,7 +273,7 @@ def fullTexTableSE( summaryTable, odir=os.getcwd() ):
 
     k = [summaryTable[key]['upirs'] for key in ks if type(key) == int]
 
-    handle.write( '& %d' % (len( set.union(*k))))
+    handle.write( '& %d' % (_union_len(k)))
     handle.write('\\\\')
     handle.write('\n')
 
@@ -279,7 +284,7 @@ def fullTexTableSE( summaryTable, odir=os.getcwd() ):
         handle.write( " & %d" % (len(summaryTable[key]['downirs'])))
 
     k = [summaryTable[key]['downirs'] for key in ks if type(key) == int ]
-    handle.write( '& %d' % (len( set.union(*k))))
+    handle.write( '& %d' % (_union_len(k)))
     handle.write('\\\\')
     handle.write('\n')
 
@@ -292,7 +297,7 @@ def fullTexTableSE( summaryTable, odir=os.getcwd() ):
 
     k = [summaryTable[key]['downirs'] for key in ks if type(key) == int]+[summaryTable[key]['upirs'] for key in ks if type(key) == int]
 
-    handle.write( '& %d' % (len( set.union(*k))))
+    handle.write( '& %d' % (_union_len(k)))
     handle.write('\\\\')
     handle.write('\n')
 
@@ -1094,5 +1099,4 @@ def plotMVASE_smear(geneRecords, aVals, odir=os.getcwd(), ext='pdf'):
     plt.savefig(os.path.join(odir,'mvaSE.%s') % (ext))
     plt.autoscale(True)
     plt.close()
-
 

--- a/iDiffIR/SpliceGrapher/SpliceGraph.py
+++ b/iDiffIR/SpliceGrapher/SpliceGraph.py
@@ -173,7 +173,7 @@ def altSiteEventList(nodes, siteType, verbose=False) :
 
     # Sorting nodes ensures that overlapping nodes will
     # not be stored in distinct sets to be merged later
-    eventNodes.sort()
+    eventNodes.sort(key=lambda node: (node.minpos, node.maxpos, node.id))
     eventList = []
     stored    = set()
     for n in eventNodes :
@@ -957,7 +957,7 @@ class SpliceGraph(object) :
         try :
             # Look for another node with the same start/end positions
             tmpNode  = NullNode(start,end)
-            allNodes = self.nodeDict.values()
+            allNodes = list(self.nodeDict.values())
             idx      = allNodes.index(tmpNode)
             node     = allNodes[idx]
         except ValueError :
@@ -1216,7 +1216,10 @@ class SpliceGraph(object) :
         keyed to a sorted list of nodes in the isoform."""
         result = {}
         nodes  = self.resolvedNodes()
-        nodes.sort(reverse=(self.strand=='-'))
+        nodes.sort(
+            key=lambda node: (node.minpos, node.maxpos, node.id),
+            reverse=(self.strand=='-'),
+        )
         for n in nodes :
             for iso in n.isoformSet :
                 result.setdefault(iso,[])

--- a/iDiffIR/SpliceGrapher/shared/GeneModelConverter.py
+++ b/iDiffIR/SpliceGrapher/shared/GeneModelConverter.py
@@ -121,13 +121,16 @@ def geneModelToSpliceGraph(gene, **args) :
     else :
         nodeSet.update(gene.exons)
 
-    nodeList = sorted(list(nodeSet)) # Needed for debugging
-    badForms = set([])
+    nodeList = sorted(
+        nodeSet,
+        key=lambda exon: (exon.minpos, exon.maxpos, exon.strand),
+    )
+    badForms = set()
     for exon in nodeList :
         exon_key = makeKey(exon)
         if exon_key in exonDict : continue
         if len(exon) < minexon :
-            badForms.update(exon.parents)
+            badForms.update(parent.id for parent in exon.parents)
             continue
 
         eid  = next(exonIds)
@@ -138,7 +141,7 @@ def geneModelToSpliceGraph(gene, **args) :
             node.addIsoform(p.id)
 
     featureList = gene.mrna.values() if useCDS else gene.isoforms.values()
-    featureList = [f for f in featureList if f not in badForms]
+    featureList = [f for f in featureList if f.id not in badForms]
     if not featureList :
         isoLen = len(gene.isoforms)
         rnaLen = len(gene.mrna)

--- a/iDiffIR/SpliceGrapher/shared/utils.py
+++ b/iDiffIR/SpliceGrapher/shared/utils.py
@@ -20,7 +20,6 @@ Module containing general utility methods.
 """
 import configparser as ConfigParser
 import gzip
-import locale
 import os
 import random
 import subprocess
@@ -79,9 +78,7 @@ def bsearch(X, target, getValue=lambda a:a, **args) :
 
 def commaFormat(d) :
     """Formats integer values using commas.  For example, 123456789 becomes '123,456,789'"""
-    # Establish user's default their OS:
-    locale.setlocale(locale.LC_ALL, '')
-    return locale.format("%d", d, grouping=True)
+    return f"{int(d):,}"
 
 def configMap(cfgFile):
     """Reads a configuration file and returns a dictionary of all sections, options and values."""

--- a/iDiffIR/Stat.py
+++ b/iDiffIR/Stat.py
@@ -298,7 +298,8 @@ def procGeneStatsIR( tasks, test_status):
                                                                        nspace.factor1bamfiles,
                                                                        nspace.factor2bamfiles
                                                                    )
-        allJcts = set.intersection( *map(set, [x.keys() for x in f1Juncs]) + map(set, [x.keys() for x in f2Juncs]) )
+        junction_sets = [set(x.keys()) for x in f1Juncs] + [set(x.keys()) for x in f2Juncs]
+        allJcts = set.intersection(*junction_sets) if junction_sets else set()
         aVals = range(nspace.krange[0], nspace.krange[1]+1)
         # nothing to test
 
@@ -542,6 +543,8 @@ def testIR(geneRecords, aVals, nspace):
                                                     for t in range(len(geneRecords[i].IRstat)) \
                                                     if geneRecords[i].IRTested[t] and geneRecords[i].IRGTested]) \
                                        for i in range(len(geneRecords)) if geneRecords[i].IRGTested]) )
+        if not X:
+            continue
         mu = numpy.mean(X)
         #mu = numpy.median(X)
 
@@ -1061,8 +1064,20 @@ def computeSE( gene, f1EV, f2EV, f1LNorm, f2LNorm):
     F2Cr = numpy.array([ numpy.array([numpy.median(f2EV[i][s:(e+1)]) \
                           for s,e in gene.exonsI]).mean() for i in range(len( f2EV))]) + EPS
 
-    F1 = numpy.array(list(chain.from_iterable( [f1ExonExp[i]*f1RepExps[i] for i in range(len(f1ExonExp))]))) + EPS
-    F2 = numpy.array(list(chain.from_iterable( [f2ExonExp[i]*f2RepExps[i] for i in range(len(f2ExonExp))]))) + EPS
+    F1 = numpy.array(
+        list(
+            chain.from_iterable(
+                [numpy.array(f1ExonExp[i]) * f1RepExps[i] for i in range(len(f1ExonExp))]
+            )
+        )
+    ) + EPS
+    F2 = numpy.array(
+        list(
+            chain.from_iterable(
+                [numpy.array(f2ExonExp[i]) * f2RepExps[i] for i in range(len(f2ExonExp))]
+            )
+        )
+    ) + EPS
     up = max(F1C.sum(), F2C.sum())
     fc = numpy.log2(F1C.mean() / F2C.mean())
     f1Exp = F1C.mean()

--- a/tests/test_runtime_unblock.py
+++ b/tests/test_runtime_unblock.py
@@ -1,0 +1,34 @@
+from iDiffIR.SpliceGrapher.formats.GeneModel import Exon, Gene, GeneModel, Isoform
+from iDiffIR.SpliceGrapher.shared.GeneModelConverter import geneModelToSpliceGraph
+from iDiffIR.SpliceGrapher.shared.utils import commaFormat
+
+
+def test_clean_name_decodes_url_escapes():
+    model = GeneModel(None)
+    assert model.cleanName("Gene%20One") == "Gene-One"
+
+
+def test_make_sorted_model_sorts_gene_objects():
+    model = GeneModel(None)
+    model.addChromosome(1, 1000, "chr1")
+    model.addGene(Gene("gene_b", "", 200, 300, "chr1", "+"))
+    model.addGene(Gene("gene_a", "", 10, 120, "chr1", "+"))
+
+    model.makeSortedModel()
+
+    assert [gene.id for gene in model.sorted["chr1"]["+"]] == ["gene_a", "gene_b"]
+
+
+def test_gene_model_to_splice_graph_sorts_exon_nodes():
+    gene = Gene("gene_a", "", 1, 200, "chr1", "+")
+    isoform = Isoform("gene_a.1", 1, 200, "chr1", "+")
+    gene.addExon(isoform, Exon(101, 150, "chr1", "+"))
+    gene.addExon(isoform, Exon(11, 60, "chr1", "+"))
+
+    graph = geneModelToSpliceGraph(gene)
+
+    assert len(graph.nodeDict) == 2
+
+
+def test_comma_format_python3_safe():
+    assert commaFormat(1234567) == "1,234,567"


### PR DESCRIPTION
## Summary
- add focused regression tests for Python 3 runtime blockers in the idiffir core path
- fix Python 3 incompatibilities in model loading/sorting/conversion and numeric formatting paths
- resolve additional directly-blocking runtime crashes discovered during the synthetic `idiffir.py -n -p 1` probe (SpliceGraph, Stat, Plot)

## Test Plan
- uv run --python 3.12 pytest -q tests/test_runtime_unblock.py
- uv run --python 3.12 pytest -q
- uv run --python 3.12 python -W error::SyntaxWarning -m compileall -f -q iDiffIR scripts tests
- uv run --python 3.12 python scripts/idiffir.py /tmp/idiffir-issueB-probe/model.gff3 /tmp/idiffir-issueB-probe/f1.bam /tmp/idiffir-issueB-probe/f2.bam -n -p 1 -o /tmp/idiffir-issueB-probe/out

Closes #22
