### PR TITLE
Fix Python 3.10 CI policy test import and docs alignment

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,6 @@ iDiffIR identifies differential intron retention from RNA-seq data.
 
 Python 2 is **formally dropped**. This project supports Python:
 
-- 3.9
 - 3.10
 - 3.11
 - 3.12
@@ -16,7 +15,7 @@ Python 2 is **formally dropped**. This project supports Python:
 ### One-time setup
 
 ```bash
-uv sync --extra dev
+uv sync --group dev
 ```
 
 This creates/uses a local virtual environment and installs project + development dependencies from `uv.lock`.
@@ -47,8 +46,7 @@ The project uses PEP 621 metadata in `pyproject.toml` with the `setuptools.build
 
 Runtime dependencies are declared in `project.dependencies`, with optional groups in:
 
-- `project.optional-dependencies.dev`
-- `project.optional-dependencies.test`
+- `[dependency-groups].dev`
 
 ## Release Notes
 

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,37 +1,40 @@
 from pathlib import Path
-import tomllib
+import re
 
 
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _ci_workflow_text() -> str:
+    return (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+
+def _pyproject_text() -> str:
+    return (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+
 def test_ci_workflow_does_not_use_python_m_pip():
-    ci_workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
-        encoding="utf-8"
-    )
+    ci_workflow = _ci_workflow_text()
     assert "python -m pip" not in ci_workflow
 
 
 def test_ci_workflow_uses_dependency_groups_not_extras():
-    ci_workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
-        encoding="utf-8"
-    )
+    ci_workflow = _ci_workflow_text()
     assert "--group" in ci_workflow
     assert "--extra test" not in ci_workflow
 
 
 def test_ci_workflow_matrix_drops_python39():
-    ci_workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
-        encoding="utf-8"
-    )
+    ci_workflow = _ci_workflow_text()
     assert '"3.9"' not in ci_workflow
     assert '"3.10"' in ci_workflow
 
 
 def test_project_requires_python_310_or_newer():
-    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
-    assert pyproject["project"]["requires-python"] == ">=3.10"
-    assert (
-        "Programming Language :: Python :: 3.9"
-        not in pyproject["project"]["classifiers"]
+    pyproject_text = _pyproject_text()
+    assert re.search(
+        r'^\s*requires-python\s*=\s*">=3\.10"\s*$',
+        pyproject_text,
+        re.MULTILINE,
     )
+    assert '"Programming Language :: Python :: 3.9"' not in pyproject_text


### PR DESCRIPTION
## Summary
- apply the post-merge follow-up commit that fixed Python 3.10 CI collection failure
- remove tomllib dependency from tests/test_ci_workflow.py and use text/regex policy checks
- align README language with current Python support and dependency-group workflow

## Verification
- uv run --python 3.10 pytest -q tests/test_ci_workflow.py
- uv run --python 3.10 pytest -q
- uv run --python 3.12 pytest -q
- uv run --python 3.12 python -W error::SyntaxWarning -m compileall -f -q iDiffIR scripts tests
- rg -n "\\btomllib\\b" tests (no matches)
