### PR TITLE
Issue #39: design PyML to sklearn migration schema

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,10 +16,10 @@ Welcome to the home of **iDiffIR**, a method for **i**\ dentifying
    installation
    tutorial
    contact
+   pyml_sklearn_migration
 
 
 *   :ref:`search`
-
 
 
 

--- a/doc/pyml_sklearn_migration.rst
+++ b/doc/pyml_sklearn_migration.rst
@@ -1,0 +1,98 @@
+PyML to scikit-learn Migration Design
+=====================================
+
+Summary
+-------
+This document defines the migration contract for SpliceGrapher classifiers currently bound to
+PyML ``.svm`` assets. The migration target is scikit-learn with serialized ``.joblib`` model
+artifacts and explicit metadata to preserve feature parity.
+
+Scope for this phase:
+
+1. lock the model API contract used by callers
+2. define feature mapping parity requirements
+3. define artifact format and metadata policy
+4. define compatibility/deprecation sequencing for legacy ``.svm`` assets
+
+Target Model API Contract
+-------------------------
+Model loading and inference paths should converge on a single runtime surface:
+
+1. ``load_model(path, metadata_path) -> model_handle``
+2. ``predict_scores(model_handle, features) -> ndarray[float]``
+3. ``predict_labels(model_handle, features, threshold) -> ndarray[int]``
+
+Contract requirements:
+
+1. binary labels are ``0/1`` and threshold defaults stay compatible with legacy classifier config
+2. both site-classification (acceptor/donor) and gap-classification tasks share the same
+   metadata-driven load path
+3. feature extraction remains outside the model object and must be versioned in metadata
+
+Feature Extraction Parity Mapping
+---------------------------------
+Parity is defined by named feature mappings, not by positional assumptions.
+
+Each migrated model metadata file must include:
+
+1. legacy feature identifier (from existing config or code path)
+2. new scikit-learn feature name emitted by extractor
+3. optional notes when one legacy feature expands into multiple normalized features
+
+For site classifiers:
+
+1. preserve k-mer window semantics from legacy config (``mink``, ``maxk``, mismatch profile)
+2. preserve sequence window boundaries (intron/exon offsets)
+
+For gap classifiers:
+
+1. preserve legacy feature names from ``GapClassifier.py`` constants
+2. preserve feature ordering through explicit metadata to avoid hidden regressions
+
+Serialized Model Format Policy
+------------------------------
+Canonical persisted format is:
+
+1. model: ``*.joblib``
+2. metadata: ``*.json`` matching ``ModelMetadata`` schema in
+   ``iDiffIR.SpliceGrapher.predict.model_schema``
+
+Metadata requirements:
+
+1. ``schema_version`` (currently ``1``)
+2. ``classifier_task`` (site_acceptor, site_donor, gap)
+3. ``artifact_format`` (joblib)
+4. ``artifact_path``
+5. ``sklearn_version``
+6. ``feature_extractor``
+7. ``feature_mappings`` list
+8. optional legacy pointers (``legacy_config_path``, ``legacy_svm_path``)
+
+Compatibility and Deprecation Plan
+----------------------------------
+Phase A (current):
+
+1. keep legacy ``.svm`` assets present
+2. add metadata schema and migration design artifacts
+3. implement migration tooling in a follow-up issue
+
+Phase B (dual-read):
+
+1. default to ``.joblib`` when metadata exists
+2. allow explicit fallback to legacy ``.svm`` path for unmigrated species bundles
+3. emit one warning per process when fallback path is used
+
+Phase C (deprecation enforcement):
+
+1. add release note announcing legacy fallback removal timeline
+2. fail closed for missing metadata in classifier bundles designated as migrated
+3. remove runtime loading from PyML in a dedicated cleanup issue
+
+Validation Criteria for Migration PRs
+-------------------------------------
+Each migration PR should satisfy:
+
+1. task-level parity tests for feature extraction outputs
+2. classifier loading tests using metadata schema round-trip
+3. deterministic inference checks for fixed synthetic inputs
+4. no user-facing CLI flag changes

--- a/iDiffIR/SpliceGrapher/predict/model_schema.py
+++ b/iDiffIR/SpliceGrapher/predict/model_schema.py
@@ -1,0 +1,138 @@
+"""Schema helpers for PyML -> scikit-learn classifier migration artifacts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "1"
+
+
+class ClassifierTask(str, Enum):
+    """Supported task types for migrated classifier artifacts."""
+
+    SITE_ACCEPTOR = "site_acceptor"
+    SITE_DONOR = "site_donor"
+    GAP = "gap"
+
+
+class ArtifactFormat(str, Enum):
+    """Supported serialization formats for migrated classifier assets."""
+
+    JOBLIB = "joblib"
+
+
+@dataclass(frozen=True)
+class FeatureMapping:
+    """Maps one legacy feature name to the new extractor output name."""
+
+    legacy_name: str
+    sklearn_name: str
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        """Serializes this feature mapping to a dict."""
+        return {
+            "legacy_name": self.legacy_name,
+            "sklearn_name": self.sklearn_name,
+            "notes": self.notes,
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> FeatureMapping:
+        """Builds a feature mapping from a dict payload."""
+        return cls(
+            legacy_name=str(value["legacy_name"]),
+            sklearn_name=str(value["sklearn_name"]),
+            notes=str(value.get("notes", "")),
+        )
+
+
+@dataclass(frozen=True)
+class ModelMetadata:
+    """Normalized metadata stored next to migrated model artifacts."""
+
+    classifier_task: ClassifierTask
+    artifact_format: ArtifactFormat
+    artifact_path: str
+    sklearn_version: str
+    feature_extractor: str
+    feature_mappings: tuple[FeatureMapping, ...]
+    threshold: float | None = None
+    legacy_config_path: str | None = None
+    legacy_svm_path: str | None = None
+    schema_version: str = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serializes model metadata to a JSON-compatible dict."""
+        return {
+            "schema_version": self.schema_version,
+            "classifier_task": self.classifier_task.value,
+            "artifact_format": self.artifact_format.value,
+            "artifact_path": self.artifact_path,
+            "sklearn_version": self.sklearn_version,
+            "feature_extractor": self.feature_extractor,
+            "feature_mappings": [mapping.to_dict() for mapping in self.feature_mappings],
+            "threshold": self.threshold,
+            "legacy_config_path": self.legacy_config_path,
+            "legacy_svm_path": self.legacy_svm_path,
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> ModelMetadata:
+        """Builds model metadata from a dict payload."""
+        schema_version = str(value.get("schema_version", SCHEMA_VERSION))
+        if schema_version != SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported model schema version '{schema_version}'; expected '{SCHEMA_VERSION}'."
+            )
+
+        mappings = tuple(
+            FeatureMapping.from_dict(item) for item in value.get("feature_mappings", [])
+        )
+        return cls(
+            classifier_task=ClassifierTask(value["classifier_task"]),
+            artifact_format=ArtifactFormat(value["artifact_format"]),
+            artifact_path=str(value["artifact_path"]),
+            sklearn_version=str(value["sklearn_version"]),
+            feature_extractor=str(value["feature_extractor"]),
+            feature_mappings=mappings,
+            threshold=_as_optional_float(value.get("threshold")),
+            legacy_config_path=_as_optional_str(value.get("legacy_config_path")),
+            legacy_svm_path=_as_optional_str(value.get("legacy_svm_path")),
+            schema_version=schema_version,
+        )
+
+
+def save_model_metadata(metadata: ModelMetadata, output_path: Path) -> None:
+    """Saves model metadata as JSON."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(metadata.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def load_model_metadata(path: Path) -> ModelMetadata:
+    """Loads model metadata from JSON."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected top-level object in {path}, got {type(payload).__name__}")
+    return ModelMetadata.from_dict(payload)
+
+
+def _as_optional_float(value: Any) -> float | None:
+    """Converts a value to float or None."""
+    if value is None:
+        return None
+    return float(value)
+
+
+def _as_optional_str(value: Any) -> str | None:
+    """Converts a value to str or None."""
+    if value is None:
+        return None
+    return str(value)

--- a/tests/test_model_schema.py
+++ b/tests/test_model_schema.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+import pytest
+
+from iDiffIR.SpliceGrapher.predict.model_schema import (
+    ArtifactFormat,
+    ClassifierTask,
+    FeatureMapping,
+    ModelMetadata,
+    load_model_metadata,
+    save_model_metadata,
+)
+
+
+def test_model_metadata_json_round_trip(tmp_path: Path) -> None:
+    metadata = ModelMetadata(
+        classifier_task=ClassifierTask.SITE_DONOR,
+        artifact_format=ArtifactFormat.JOBLIB,
+        artifact_path="models/gt_don.joblib",
+        sklearn_version="1.5.2",
+        feature_extractor="kmer_window_v1",
+        feature_mappings=(
+            FeatureMapping(legacy_name="mink", sklearn_name="kmer_min"),
+            FeatureMapping(legacy_name="maxk", sklearn_name="kmer_max"),
+        ),
+        threshold=0.47,
+        legacy_config_path="gt_don.cfg",
+        legacy_svm_path="gt_don.svm",
+    )
+
+    metadata_path = tmp_path / "migrated" / "gt_don.metadata.json"
+    save_model_metadata(metadata, metadata_path)
+
+    loaded = load_model_metadata(metadata_path)
+    assert loaded == metadata
+
+
+def test_model_metadata_rejects_unsupported_schema_version() -> None:
+    payload = {
+        "schema_version": "99",
+        "classifier_task": "gap",
+        "artifact_format": "joblib",
+        "artifact_path": "models/gap.joblib",
+        "sklearn_version": "1.5.2",
+        "feature_extractor": "gap_features_v1",
+        "feature_mappings": [],
+    }
+
+    with pytest.raises(ValueError, match="Unsupported model schema version"):
+        ModelMetadata.from_dict(payload)
+
+
+def test_model_metadata_rejects_unknown_classifier_task() -> None:
+    payload = {
+        "schema_version": "1",
+        "classifier_task": "unknown_task",
+        "artifact_format": "joblib",
+        "artifact_path": "models/model.joblib",
+        "sklearn_version": "1.5.2",
+        "feature_extractor": "features_v1",
+        "feature_mappings": [],
+    }
+
+    with pytest.raises(ValueError, match="unknown_task"):
+        ModelMetadata.from_dict(payload)


### PR DESCRIPTION
## Summary
- add migration design doc for PyML -> scikit-learn classifier modernization
- introduce typed model metadata schema (`ModelMetadata`) and helpers for JSON round-trip
- cover schema behavior with unit tests for round-trip and validation failures

## Files
- `doc/pyml_sklearn_migration.rst`
- `doc/index.rst`
- `iDiffIR/SpliceGrapher/predict/model_schema.py`
- `tests/test_model_schema.py`

## Verification
- `uv run ruff check iDiffIR/SpliceGrapher/predict/model_schema.py tests/test_model_schema.py`
- `uv run pytest -q tests/test_model_schema.py`
- `uv run pytest -q`
- `uv run python -W error::SyntaxWarning -m compileall -f -q iDiffIR scripts tests`

Closes #39
