### PR TITLE
Issue #60: Extract NetworkX splice-core and sklearn/skops filtering

### DIFF
--- a/iDiffIR/splice_core/__init__.py
+++ b/iDiffIR/splice_core/__init__.py
@@ -1,0 +1,41 @@
+"""Modern splice-core APIs shared across iDiffIR and TAPIS."""
+
+from iDiffIR.splice_core.events import (
+    AlternativeSpliceSiteEvent,
+    AlternativeSpliceSiteType,
+    ExonSkippingEvent,
+    IntronRetentionEvent,
+    detect_alternative_splice_sites,
+    detect_exon_skipping,
+    detect_intron_retention,
+)
+from iDiffIR.splice_core.filtering import (
+    SequenceSiteContext,
+    SequenceSiteLabel,
+    SpliceSiteSvmModel,
+    SpliceSiteType,
+    TrainableSequenceRecord,
+    extract_sequence_context,
+    load_splice_site_model,
+)
+from iDiffIR.splice_core.graph import IntronSupport, SpliceGraphContext, build_splice_graph
+
+__all__ = [
+    "AlternativeSpliceSiteEvent",
+    "AlternativeSpliceSiteType",
+    "ExonSkippingEvent",
+    "IntronRetentionEvent",
+    "IntronSupport",
+    "SequenceSiteContext",
+    "SequenceSiteLabel",
+    "SpliceGraphContext",
+    "SpliceSiteSvmModel",
+    "SpliceSiteType",
+    "TrainableSequenceRecord",
+    "build_splice_graph",
+    "detect_alternative_splice_sites",
+    "detect_exon_skipping",
+    "detect_intron_retention",
+    "extract_sequence_context",
+    "load_splice_site_model",
+]

--- a/iDiffIR/splice_core/events.py
+++ b/iDiffIR/splice_core/events.py
@@ -1,0 +1,247 @@
+"""Deterministic traversal queries over splice-core NetworkX graphs."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from enum import Enum
+
+from iDiffIR.splice_core.graph import IntronSupport, NodeKey, SpliceGraphContext
+
+
+class AlternativeSpliceSiteType(str, Enum):
+    """Alternative splice-site classes represented in traversal outputs."""
+
+    ALT5 = "alt5"
+    ALT3 = "alt3"
+
+
+@dataclass(frozen=True)
+class IntronRetentionEvent:
+    """Intron-retention evidence summary for one intron span."""
+
+    gene_id: str
+    chrom: str
+    strand: str
+    intron_start: int
+    intron_end: int
+    retained_support: int
+    spliced_support: int
+    retained_ratio: float
+
+
+@dataclass(frozen=True)
+class ExonSkippingEvent:
+    """Exon-skipping evidence summary around one candidate skipped exon."""
+
+    gene_id: str
+    chrom: str
+    strand: str
+    skipped_exon_start: int
+    skipped_exon_end: int
+    skipped_junction_support: int
+    included_junction_support: int
+
+
+@dataclass(frozen=True)
+class AlternativeSpliceSiteEvent:
+    """Alternative donor/acceptor event summary."""
+
+    gene_id: str
+    chrom: str
+    strand: str
+    site_type: AlternativeSpliceSiteType
+    donor_position: int
+    acceptor_position: int
+    support: int
+
+
+def detect_intron_retention(
+    context: SpliceGraphContext,
+    *,
+    min_retained_support: int = 1,
+    min_total_support: int = 1,
+) -> list[IntronRetentionEvent]:
+    """Detect intron-retention events from intron support summaries."""
+    events: list[IntronRetentionEvent] = []
+    for intron in context.introns:
+        if intron.retained_support < min_retained_support:
+            continue
+        total = intron.retained_support + intron.junction_support
+        if total < min_total_support:
+            continue
+        retained_ratio = float(intron.retained_support) / float(total)
+        events.append(
+            IntronRetentionEvent(
+                gene_id=intron.gene_id,
+                chrom=intron.chrom,
+                strand=intron.strand,
+                intron_start=intron.intron_start,
+                intron_end=intron.intron_end,
+                retained_support=intron.retained_support,
+                spliced_support=intron.junction_support,
+                retained_ratio=retained_ratio,
+            )
+        )
+    events.sort(
+        key=lambda event: (
+            event.chrom,
+            event.gene_id,
+            event.intron_start,
+            event.intron_end,
+        )
+    )
+    return events
+
+
+def detect_exon_skipping(
+    context: SpliceGraphContext,
+    *,
+    min_skip_support: int = 1,
+    min_include_support: int = 1,
+) -> list[ExonSkippingEvent]:
+    """Detect exon-skipping events using local predecessor/successor topology."""
+    graph = context.graph
+    signatures: set[tuple[str, str, int, int, NodeKey, NodeKey]] = set()
+    events: list[ExonSkippingEvent] = []
+
+    for node_key in graph.nodes:
+        node_data = graph.nodes[node_key]
+        predecessors = sorted(graph.predecessors(node_key))
+        successors = sorted(graph.successors(node_key))
+        for predecessor_key in predecessors:
+            for successor_key in successors:
+                if not graph.has_edge(predecessor_key, successor_key):
+                    continue
+                skipped_support = int(
+                    graph[predecessor_key][successor_key].get("junction_support", 0)
+                )
+                if skipped_support < min_skip_support:
+                    continue
+                included_support = int(
+                    graph[predecessor_key][node_key].get("junction_support", 0)
+                ) + int(
+                    graph[node_key][successor_key].get("junction_support", 0)
+                )
+                if included_support < min_include_support:
+                    continue
+                signature = (
+                    str(node_data["gene_id"]),
+                    str(node_data["chrom"]),
+                    int(node_data["start"]),
+                    int(node_data["end"]),
+                    predecessor_key,
+                    successor_key,
+                )
+                if signature in signatures:
+                    continue
+                signatures.add(signature)
+                events.append(
+                    ExonSkippingEvent(
+                        gene_id=str(node_data["gene_id"]),
+                        chrom=str(node_data["chrom"]),
+                        strand=str(node_data["strand"]),
+                        skipped_exon_start=int(node_data["start"]),
+                        skipped_exon_end=int(node_data["end"]),
+                        skipped_junction_support=skipped_support,
+                        included_junction_support=included_support,
+                    )
+                )
+
+    events.sort(
+        key=lambda event: (
+            event.chrom,
+            event.gene_id,
+            event.skipped_exon_start,
+            event.skipped_exon_end,
+        )
+    )
+    return events
+
+
+def detect_alternative_splice_sites(
+    context: SpliceGraphContext,
+    *,
+    min_support: int = 1,
+) -> list[AlternativeSpliceSiteEvent]:
+    """Detect ALT5/ALT3 events from per-intron donor/acceptor support groups."""
+    introns = [intron for intron in context.introns if intron.junction_support >= min_support]
+    events: list[AlternativeSpliceSiteEvent] = []
+    event_signatures: set[tuple[str, str, str, str, int, int]] = set()
+
+    donor_groups: dict[tuple[str, str, str, int], list[IntronSupport]] = defaultdict(list)
+    acceptor_groups: dict[tuple[str, str, str, int], list[IntronSupport]] = defaultdict(list)
+    for intron in introns:
+        donor_groups[
+            (intron.gene_id, intron.chrom, intron.strand, intron.donor_position)
+        ].append(intron)
+        acceptor_groups[
+            (intron.gene_id, intron.chrom, intron.strand, intron.acceptor_position)
+        ].append(intron)
+
+    for (gene_id, chrom, strand, donor_position), grouped_introns in donor_groups.items():
+        acceptor_positions = sorted({intron.acceptor_position for intron in grouped_introns})
+        if len(acceptor_positions) < 2:
+            continue
+        for intron in grouped_introns:
+            signature = (
+                gene_id,
+                chrom,
+                strand,
+                AlternativeSpliceSiteType.ALT3.value,
+                donor_position,
+                intron.acceptor_position,
+            )
+            if signature in event_signatures:
+                continue
+            event_signatures.add(signature)
+            events.append(
+                AlternativeSpliceSiteEvent(
+                    gene_id=gene_id,
+                    chrom=chrom,
+                    strand=strand,
+                    site_type=AlternativeSpliceSiteType.ALT3,
+                    donor_position=donor_position,
+                    acceptor_position=intron.acceptor_position,
+                    support=intron.junction_support,
+                )
+            )
+
+    for (gene_id, chrom, strand, acceptor_position), grouped_introns in acceptor_groups.items():
+        donor_positions = sorted({intron.donor_position for intron in grouped_introns})
+        if len(donor_positions) < 2:
+            continue
+        for intron in grouped_introns:
+            signature = (
+                gene_id,
+                chrom,
+                strand,
+                AlternativeSpliceSiteType.ALT5.value,
+                intron.donor_position,
+                acceptor_position,
+            )
+            if signature in event_signatures:
+                continue
+            event_signatures.add(signature)
+            events.append(
+                AlternativeSpliceSiteEvent(
+                    gene_id=gene_id,
+                    chrom=chrom,
+                    strand=strand,
+                    site_type=AlternativeSpliceSiteType.ALT5,
+                    donor_position=intron.donor_position,
+                    acceptor_position=acceptor_position,
+                    support=intron.junction_support,
+                )
+            )
+
+    events.sort(
+        key=lambda event: (
+            event.chrom,
+            event.gene_id,
+            event.site_type.value,
+            event.donor_position,
+            event.acceptor_position,
+        )
+    )
+    return events

--- a/iDiffIR/splice_core/filtering.py
+++ b/iDiffIR/splice_core/filtering.py
@@ -1,0 +1,326 @@
+"""Modern sklearn/skops splice-site filtering primitives."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum, IntEnum
+from pathlib import Path
+from typing import Protocol, cast
+
+import numpy as np
+import pysam
+
+
+class SpliceSiteType(str, Enum):
+    """Splice-site classes consumed by context extraction and classification."""
+
+    DONOR = "donor"
+    ACCEPTOR = "acceptor"
+
+
+class SequenceSiteLabel(IntEnum):
+    """Binary labels used for training splice-site SVM classifiers."""
+
+    NEGATIVE = 0
+    POSITIVE = 1
+
+
+@dataclass(frozen=True)
+class TrainableSequenceRecord:
+    """One labeled sequence row for SVM training."""
+
+    sequence: str
+    label: SequenceSiteLabel
+
+
+@dataclass(frozen=True)
+class SequenceSiteContext:
+    """Extracted sequence context around one genomic splice-site position."""
+
+    chrom: str
+    position: int
+    strand: str
+    site_type: SpliceSiteType
+    exon_sequence: str
+    intron_sequence: str
+    model_sequence: str
+    dimer: str
+
+
+@dataclass(frozen=True)
+class SpliceSiteModelMetadata:
+    """Metadata persisted with secure sklearn model artifacts."""
+
+    site_type: SpliceSiteType
+    dimer: str
+    exon_window: int
+    intron_window: int
+    threshold: float
+    ngram_min: int
+    ngram_max: int
+    schema_version: str = "1"
+
+    def to_dict(self) -> dict[str, str | int | float]:
+        """Serialize metadata to JSON-compatible dict."""
+        return {
+            "schema_version": self.schema_version,
+            "site_type": self.site_type.value,
+            "dimer": self.dimer,
+            "exon_window": self.exon_window,
+            "intron_window": self.intron_window,
+            "threshold": self.threshold,
+            "ngram_min": self.ngram_min,
+            "ngram_max": self.ngram_max,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, object]) -> SpliceSiteModelMetadata:
+        """Parse metadata from a JSON dict payload."""
+        return cls(
+            site_type=SpliceSiteType(str(payload["site_type"])),
+            dimer=str(payload["dimer"]),
+            exon_window=int(payload["exon_window"]),
+            intron_window=int(payload["intron_window"]),
+            threshold=float(payload["threshold"]),
+            ngram_min=int(payload["ngram_min"]),
+            ngram_max=int(payload["ngram_max"]),
+            schema_version=str(payload.get("schema_version", "1")),
+        )
+
+
+class _SequenceModel(Protocol):
+    """Minimal sklearn-like contract needed by this module."""
+
+    def fit(self, sequences: list[str], labels: np.ndarray) -> _SequenceModel:
+        """Train the model on sequence strings."""
+
+    def predict(self, sequences: list[str]) -> np.ndarray:
+        """Predict class labels for sequence strings."""
+
+    def decision_function(self, sequences: list[str]) -> np.ndarray:
+        """Return decision-function scores for sequence strings."""
+
+
+class SpliceSiteSvmModel:
+    """Securely persisted char-kmer SVM classifier for splice-site filtering."""
+
+    def __init__(self, *, pipeline: _SequenceModel, metadata: SpliceSiteModelMetadata) -> None:
+        """Store trained pipeline and model metadata."""
+        self._pipeline = pipeline
+        self.metadata = metadata
+
+    @classmethod
+    def train(
+        cls,
+        records: list[TrainableSequenceRecord],
+        *,
+        site_type: SpliceSiteType = SpliceSiteType.DONOR,
+        dimer: str = "GT",
+        exon_window: int = 8,
+        intron_window: int = 15,
+        threshold: float = 0.0,
+        ngram_min: int = 1,
+        ngram_max: int = 3,
+        c_value: float = 1.0,
+    ) -> SpliceSiteSvmModel:
+        """Train one SVC model with explicit StandardScaler normalization."""
+        if not records:
+            raise ValueError("At least one training record is required.")
+
+        from sklearn.feature_extraction.text import CountVectorizer
+        from sklearn.pipeline import Pipeline
+        from sklearn.preprocessing import StandardScaler
+        from sklearn.svm import SVC
+
+        sequences = [record.sequence.upper() for record in records]
+        labels = np.asarray([int(record.label) for record in records], dtype=np.int64)
+        pipeline = cast(
+            _SequenceModel,
+            Pipeline(
+                [
+                    (
+                        "vectorizer",
+                        CountVectorizer(
+                            analyzer="char",
+                            ngram_range=(ngram_min, ngram_max),
+                            lowercase=False,
+                        ),
+                    ),
+                    ("scaler", StandardScaler(with_mean=False)),
+                    ("svc", SVC(C=c_value, kernel="linear", class_weight="balanced")),
+                ]
+            ),
+        )
+        pipeline.fit(sequences, labels)
+        metadata = SpliceSiteModelMetadata(
+            site_type=site_type,
+            dimer=dimer.upper(),
+            exon_window=exon_window,
+            intron_window=intron_window,
+            threshold=threshold,
+            ngram_min=ngram_min,
+            ngram_max=ngram_max,
+        )
+        return cls(pipeline=pipeline, metadata=metadata)
+
+    def predict_labels(self, sequences: list[str]) -> np.ndarray:
+        """Predict integer class labels for sequence strings."""
+        normalized_sequences = [sequence.upper() for sequence in sequences]
+        return np.asarray(self._pipeline.predict(normalized_sequences), dtype=np.int64)
+
+    def predict_scores(self, sequences: list[str]) -> np.ndarray:
+        """Predict decision-function scores for sequence strings."""
+        scores = self._pipeline.decision_function([sequence.upper() for sequence in sequences])
+        return np.atleast_1d(np.asarray(scores, dtype=np.float64))
+
+    def classify_context(self, context: SequenceSiteContext) -> tuple[int, float]:
+        """Classify one extracted sequence context and return `(label, score)`."""
+        score = float(self.predict_scores([context.model_sequence])[0])
+        label = int(score > self.metadata.threshold)
+        return label, score
+
+    def save(self, *, artifact_path: Path, metadata_path: Path) -> None:
+        """Persist model pipeline with skops plus sidecar JSON metadata."""
+        import skops.io as skops_io
+
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        metadata_path.parent.mkdir(parents=True, exist_ok=True)
+        skops_io.dump(self._pipeline, str(artifact_path))
+        metadata_path.write_text(
+            json.dumps(self.metadata.to_dict(), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    @classmethod
+    def load(cls, *, artifact_path: Path, metadata_path: Path) -> SpliceSiteSvmModel:
+        """Load a persisted model and metadata pair from disk."""
+        import skops.io as skops_io
+
+        payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"Expected JSON object in {metadata_path}")
+        metadata = SpliceSiteModelMetadata.from_dict(payload)
+        untrusted_types = skops_io.get_untrusted_types(file=str(artifact_path))
+        pipeline = cast(_SequenceModel, skops_io.load(str(artifact_path), trusted=untrusted_types))
+        return cls(pipeline=pipeline, metadata=metadata)
+
+
+def load_splice_site_model(spec_path: str | Path) -> SpliceSiteSvmModel:
+    """Load one model bundle from either `.skops` or `.metadata.json` path."""
+    artifact_path, metadata_path = _resolve_bundle_paths(Path(spec_path))
+    return SpliceSiteSvmModel.load(artifact_path=artifact_path, metadata_path=metadata_path)
+
+
+def extract_sequence_context(
+    *,
+    fasta_path: str | Path,
+    chrom: str,
+    position: int,
+    strand: str,
+    site_type: SpliceSiteType,
+    exon_window: int,
+    intron_window: int,
+) -> SequenceSiteContext:
+    """Extract exon/intron sequence context with deterministic orientation handling."""
+    if strand not in {"+", "-"}:
+        raise ValueError("strand must be '+' or '-'")
+    if position < 1:
+        raise ValueError("position must be a 1-based genomic coordinate")
+    if exon_window < 1 or intron_window < 2:
+        raise ValueError("exon_window must be >=1 and intron_window must be >=2")
+
+    with pysam.FastaFile(str(fasta_path)) as reference:
+        exon_start, exon_end, intron_start, intron_end = _window_coordinates(
+            position=position,
+            strand=strand,
+            site_type=site_type,
+            exon_window=exon_window,
+            intron_window=intron_window,
+        )
+        exon_sequence = _fetch_one_based(
+            reference=reference,
+            chrom=chrom,
+            start=exon_start,
+            end=exon_end,
+        )
+        intron_sequence = _fetch_one_based(
+            reference=reference,
+            chrom=chrom,
+            start=intron_start,
+            end=intron_end,
+        )
+
+    if strand == "-":
+        exon_sequence = _reverse_complement(exon_sequence)
+        intron_sequence = _reverse_complement(intron_sequence)
+
+    if site_type == SpliceSiteType.DONOR:
+        model_sequence = exon_sequence + intron_sequence
+        dimer = intron_sequence[:2]
+    else:
+        model_sequence = intron_sequence + exon_sequence
+        dimer = intron_sequence[-2:]
+
+    return SequenceSiteContext(
+        chrom=chrom,
+        position=position,
+        strand=strand,
+        site_type=site_type,
+        exon_sequence=exon_sequence.upper(),
+        intron_sequence=intron_sequence.upper(),
+        model_sequence=model_sequence.upper(),
+        dimer=dimer.upper(),
+    )
+
+
+def _window_coordinates(
+    *,
+    position: int,
+    strand: str,
+    site_type: SpliceSiteType,
+    exon_window: int,
+    intron_window: int,
+) -> tuple[int, int, int, int]:
+    """Compute exon/intron windows around one splice-site position."""
+    if site_type == SpliceSiteType.DONOR and strand == "+":
+        return position - exon_window + 1, position, position + 1, position + intron_window
+    if site_type == SpliceSiteType.DONOR and strand == "-":
+        return position, position + exon_window - 1, position - intron_window, position - 1
+    if site_type == SpliceSiteType.ACCEPTOR and strand == "+":
+        return position, position + exon_window - 1, position - intron_window, position - 1
+    return position - exon_window + 1, position, position + 1, position + intron_window
+
+
+def _fetch_one_based(*, reference: pysam.FastaFile, chrom: str, start: int, end: int) -> str:
+    """Fetch an inclusive 1-based reference interval from FASTA."""
+    if start < 1 or end < start:
+        raise ValueError(f"Invalid reference window [{start}, {end}]")
+    return reference.fetch(chrom, start - 1, end)
+
+
+def _reverse_complement(sequence: str) -> str:
+    """Return DNA reverse complement for uppercase/lowercase ASCII sequence."""
+    translation = str.maketrans("ACGTacgtNn", "TGCAtgcaNn")
+    return sequence.translate(translation)[::-1]
+
+
+def _resolve_bundle_paths(spec_path: Path) -> tuple[Path, Path]:
+    """Resolve artifact and metadata paths from one user-provided model spec path."""
+    if spec_path.suffix == ".skops":
+        artifact_path = spec_path
+        metadata_path = spec_path.with_suffix(".metadata.json")
+        return artifact_path, metadata_path
+    if spec_path.name.endswith(".metadata.json"):
+        artifact_name = spec_path.name[: -len(".metadata.json")] + ".skops"
+        artifact_path = spec_path.with_name(artifact_name)
+        metadata_path = spec_path
+        return artifact_path, metadata_path
+    if spec_path.suffix == ".json":
+        artifact_path = spec_path.with_suffix(".skops")
+        metadata_path = spec_path
+        return artifact_path, metadata_path
+    raise ValueError(
+        f"Unsupported model specification path '{spec_path}'. "
+        "Use either <name>.skops or <name>.metadata.json."
+    )

--- a/iDiffIR/splice_core/graph.py
+++ b/iDiffIR/splice_core/graph.py
@@ -1,0 +1,323 @@
+"""Build deterministic splice DAGs from annotations and alignment support."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from enum import IntEnum
+from pathlib import Path
+
+import networkx as nx
+import pysam
+
+from iDiffIR.SpliceGrapher.formats.annotation_io import load_gene_models
+
+
+class CigarOperation(IntEnum):
+    """SAM/BAM CIGAR operations encoded by pysam."""
+
+    MATCH = 0
+    INSERTION = 1
+    DELETION = 2
+    REFERENCE_SKIP = 3
+    SOFT_CLIP = 4
+    HARD_CLIP = 5
+    PADDING = 6
+    SEQUENCE_MATCH = 7
+    SEQUENCE_MISMATCH = 8
+
+
+REFERENCE_ADVANCING_OPS = {
+    CigarOperation.MATCH,
+    CigarOperation.DELETION,
+    CigarOperation.REFERENCE_SKIP,
+    CigarOperation.SEQUENCE_MATCH,
+    CigarOperation.SEQUENCE_MISMATCH,
+}
+
+NodeKey = tuple[str, int, int, str]
+IntronKey = tuple[str, str, str, int, int]
+
+
+@dataclass
+class IntronSupport:
+    """Support metrics for one annotated intron span."""
+
+    chrom: str
+    gene_id: str
+    strand: str
+    intron_start: int
+    intron_end: int
+    donor_position: int
+    acceptor_position: int
+    annotation_support: int = 0
+    junction_support: int = 0
+    retained_support: int = 0
+
+
+@dataclass(frozen=True)
+class SpliceGraphContext:
+    """Container for a splice DAG and per-intron support metrics."""
+
+    graph: nx.DiGraph
+    introns: tuple[IntronSupport, ...]
+
+
+def build_splice_graph(
+    *,
+    annotation_path: str | Path,
+    alignment_path: str | Path | None = None,
+) -> SpliceGraphContext:
+    """Construct a deterministic splice DAG from annotation and optional alignment evidence."""
+    annotation_model = load_gene_models(str(annotation_path))
+    graph = nx.DiGraph()
+    intron_by_key: dict[IntronKey, IntronSupport] = {}
+    intron_to_edges: dict[IntronKey, list[tuple[NodeKey, NodeKey]]] = defaultdict(list)
+
+    sorted_genes = sorted(
+        annotation_model.getAllGenes(),
+        key=lambda item: (item.chromosome, item.minpos, item.id),
+    )
+    for gene in sorted_genes:
+        transcript_items = sorted(gene.isoforms.items(), key=lambda item: item[0])
+        for transcript_id, isoform in transcript_items:
+            exons = sorted(
+                isoform.exons,
+                key=lambda exon: (exon.minpos, exon.maxpos),
+                reverse=gene.strand == "-",
+            )
+            if len(exons) < 2:
+                continue
+            for exon in exons:
+                node_key = _node_key(gene.id, exon.minpos, exon.maxpos, gene.strand)
+                if node_key not in graph:
+                    graph.add_node(
+                        node_key,
+                        chrom=gene.chromosome,
+                        gene_id=gene.id,
+                        strand=gene.strand,
+                        start=exon.minpos,
+                        end=exon.maxpos,
+                        transcript_ids={transcript_id},
+                    )
+                else:
+                    graph.nodes[node_key]["transcript_ids"].add(transcript_id)
+
+            for upstream, downstream in zip(exons[:-1], exons[1:]):
+                upstream_key = _node_key(gene.id, upstream.minpos, upstream.maxpos, gene.strand)
+                downstream_key = _node_key(
+                    gene.id,
+                    downstream.minpos,
+                    downstream.maxpos,
+                    gene.strand,
+                )
+                intron_start = min(upstream.maxpos, downstream.maxpos) + 1
+                intron_end = max(upstream.minpos, downstream.minpos) - 1
+                if intron_start > intron_end:
+                    continue
+
+                donor_position, acceptor_position = _splice_boundaries(
+                    strand=gene.strand,
+                    intron_start=intron_start,
+                    intron_end=intron_end,
+                )
+                intron_key = _intron_key(
+                    chrom=gene.chromosome,
+                    gene_id=gene.id,
+                    strand=gene.strand,
+                    intron_start=intron_start,
+                    intron_end=intron_end,
+                )
+                intron = intron_by_key.get(intron_key)
+                if intron is None:
+                    intron = IntronSupport(
+                        chrom=gene.chromosome,
+                        gene_id=gene.id,
+                        strand=gene.strand,
+                        intron_start=intron_start,
+                        intron_end=intron_end,
+                        donor_position=donor_position,
+                        acceptor_position=acceptor_position,
+                    )
+                    intron_by_key[intron_key] = intron
+                intron.annotation_support += 1
+                intron_to_edges[intron_key].append((upstream_key, downstream_key))
+
+                if graph.has_edge(upstream_key, downstream_key):
+                    edge = graph[upstream_key][downstream_key]
+                    edge["annotation_support"] += 1
+                    edge["transcript_ids"].add(transcript_id)
+                else:
+                    graph.add_edge(
+                        upstream_key,
+                        downstream_key,
+                        intron_start=intron_start,
+                        intron_end=intron_end,
+                        intron_key=intron_key,
+                        annotation_support=1,
+                        junction_support=0,
+                        retained_support=0,
+                        transcript_ids={transcript_id},
+                    )
+
+    if alignment_path is not None and intron_by_key:
+        _apply_alignment_support(
+            alignment_path=Path(alignment_path),
+            intron_by_key=intron_by_key,
+            intron_to_edges=intron_to_edges,
+            graph=graph,
+        )
+
+    if not nx.is_directed_acyclic_graph(graph):
+        raise ValueError("Splice graph must be acyclic after annotation/alignment ingest.")
+
+    introns = tuple(
+        sorted(
+            intron_by_key.values(),
+            key=lambda intron: (
+                intron.chrom,
+                intron.gene_id,
+                intron.intron_start,
+                intron.intron_end,
+            ),
+        )
+    )
+    return SpliceGraphContext(graph=graph, introns=introns)
+
+
+def _apply_alignment_support(
+    *,
+    alignment_path: Path,
+    intron_by_key: dict[IntronKey, IntronSupport],
+    intron_to_edges: dict[IntronKey, list[tuple[NodeKey, NodeKey]]],
+    graph: nx.DiGraph,
+) -> None:
+    """Populate junction and retained-read support from one SAM/BAM/CRAM file."""
+    introns_by_chrom: dict[str, list[IntronSupport]] = defaultdict(list)
+    introns_by_span: dict[tuple[str, int, int], list[IntronKey]] = defaultdict(list)
+    for intron_key, intron in intron_by_key.items():
+        introns_by_chrom[intron.chrom].append(intron)
+        introns_by_span[(intron.chrom, intron.intron_start, intron.intron_end)].append(intron_key)
+
+    for chrom in introns_by_chrom:
+        introns_by_chrom[chrom].sort(key=lambda intron: (intron.intron_start, intron.intron_end))
+
+    with pysam.AlignmentFile(
+        str(alignment_path),
+        _alignment_mode(alignment_path),
+    ) as alignment_stream:
+        for read in alignment_stream.fetch(until_eof=True):
+            if read.is_unmapped or read.reference_id < 0:
+                continue
+            chrom = alignment_stream.get_reference_name(read.reference_id)
+            introns = introns_by_chrom.get(chrom)
+            if not introns:
+                continue
+            _update_junction_support(
+                read=read,
+                chrom=chrom,
+                introns_by_span=introns_by_span,
+                intron_by_key=intron_by_key,
+            )
+            _update_retained_support(read=read, introns=introns)
+
+    for intron_key, intron in intron_by_key.items():
+        for upstream_key, downstream_key in intron_to_edges[intron_key]:
+            edge = graph[upstream_key][downstream_key]
+            edge["junction_support"] = intron.junction_support
+            edge["retained_support"] = intron.retained_support
+
+
+def _update_junction_support(
+    *,
+    read: pysam.AlignedSegment,
+    chrom: str,
+    introns_by_span: dict[tuple[str, int, int], list[IntronKey]],
+    intron_by_key: dict[IntronKey, IntronSupport],
+) -> None:
+    """Increment per-intron junction support for reference-skip CIGAR operations."""
+    if not read.cigartuples:
+        return
+    ref_pos = read.reference_start + 1
+    for op_code, op_length in read.cigartuples:
+        cigar_op = CigarOperation(op_code)
+        if cigar_op == CigarOperation.REFERENCE_SKIP:
+            intron_start = ref_pos
+            intron_end = ref_pos + op_length - 1
+            intron_keys = introns_by_span.get((chrom, intron_start, intron_end), ())
+            for intron_key in intron_keys:
+                intron_by_key[intron_key].junction_support += 1
+            ref_pos += op_length
+            continue
+        if cigar_op in REFERENCE_ADVANCING_OPS:
+            ref_pos += op_length
+
+
+def _update_retained_support(*, read: pysam.AlignedSegment, introns: list[IntronSupport]) -> None:
+    """Increment retained support when one aligned block spans an intron interior."""
+    blocks = read.get_blocks()
+    if not blocks:
+        return
+    block_ranges = [(block_start + 1, block_end) for block_start, block_end in blocks]
+    read_start = block_ranges[0][0]
+    read_end = block_ranges[-1][1]
+
+    for intron in introns:
+        if intron.intron_start < read_start:
+            continue
+        if intron.intron_start > read_end:
+            break
+        if intron.intron_end > read_end:
+            continue
+        if _spans_intron(
+            block_ranges=block_ranges,
+            intron_start=intron.intron_start,
+            intron_end=intron.intron_end,
+        ):
+            intron.retained_support += 1
+
+
+def _spans_intron(
+    *,
+    block_ranges: list[tuple[int, int]],
+    intron_start: int,
+    intron_end: int,
+) -> bool:
+    """Return True when any contiguous alignment block covers the full intron span."""
+    for block_start, block_end in block_ranges:
+        if block_start <= intron_start and block_end >= intron_end:
+            return True
+    return False
+
+
+def _alignment_mode(path: Path) -> str:
+    """Select pysam alignment mode from file extension."""
+    suffix = path.suffix.lower()
+    if suffix == ".sam":
+        return "r"
+    if suffix == ".cram":
+        return "rc"
+    return "rb"
+
+
+def _node_key(gene_id: str, start: int, end: int, strand: str) -> NodeKey:
+    """Return deterministic exon node identity."""
+    return gene_id, start, end, strand
+
+
+def _intron_key(
+    chrom: str,
+    gene_id: str,
+    strand: str,
+    intron_start: int,
+    intron_end: int,
+) -> IntronKey:
+    """Return deterministic intron identity."""
+    return chrom, gene_id, strand, intron_start, intron_end
+
+
+def _splice_boundaries(*, strand: str, intron_start: int, intron_end: int) -> tuple[int, int]:
+    """Return donor/acceptor positions from genomic intron boundaries."""
+    if strand == "-":
+        return intron_end + 1, intron_start - 1
+    return intron_start - 1, intron_end + 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,16 @@ classifiers = [
   "License :: OSI Approved :: GNU General Public License (GPL)",
   "Operating System :: OS Independent",
 ]
-dependencies = ["scipy", "numpy", "matplotlib", "pysam", "gffutils>=0.13"]
+dependencies = [
+    "scipy",
+    "numpy",
+    "matplotlib",
+    "pysam",
+    "gffutils>=0.13",
+    "networkx>=3.4.2",
+    "scikit-learn>=1.7.2",
+    "skops>=0.13.0",
+]
 
 [project.scripts]
 "idiffir.py" = "scripts.idiffir:main"
@@ -38,6 +47,7 @@ dependencies = ["scipy", "numpy", "matplotlib", "pysam", "gffutils>=0.13"]
 "get_intron_expression.py" = "scripts.get_intron_expression:main"
 "run_miso_ir.py" = "scripts.run_miso_ir:main"
 "migrate_classifier_archives.py" = "scripts.migrate_classifier_archives:main"
+"train_splice_site_svm.py" = "scripts.train_splice_site_svm:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["iDiffIR", "scripts"]

--- a/scripts/train_splice_site_svm.py
+++ b/scripts/train_splice_site_svm.py
@@ -1,0 +1,136 @@
+"""Train a modern splice-site SVM and persist it with skops metadata."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+from iDiffIR.splice_core.filtering import (
+    SequenceSiteLabel,
+    SpliceSiteSvmModel,
+    SpliceSiteType,
+    TrainableSequenceRecord,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build CLI parser for splice-site model training."""
+    parser = argparse.ArgumentParser(
+        description="Train a splice-site SVM from tabular sequence labels.",
+    )
+    parser.add_argument(
+        "--dataset",
+        required=True,
+        help="Path to TSV with columns: sequence,label",
+    )
+    parser.add_argument(
+        "--artifact",
+        required=True,
+        help="Output .skops model path.",
+    )
+    parser.add_argument(
+        "--metadata",
+        required=True,
+        help="Output metadata JSON path.",
+    )
+    parser.add_argument(
+        "--site-type",
+        choices=[SpliceSiteType.DONOR.value, SpliceSiteType.ACCEPTOR.value],
+        default=SpliceSiteType.DONOR.value,
+        help="Classifier site type.",
+    )
+    parser.add_argument(
+        "--dimer",
+        default="GT",
+        help="Expected splice-site dimer for this classifier.",
+    )
+    parser.add_argument(
+        "--exon-window",
+        type=int,
+        default=8,
+        help="Exonic context window length.",
+    )
+    parser.add_argument(
+        "--intron-window",
+        type=int,
+        default=15,
+        help="Intronic context window length.",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.0,
+        help="Decision-function threshold for positive calls.",
+    )
+    parser.add_argument(
+        "--ngram-min",
+        type=int,
+        default=1,
+        help="Minimum character n-gram size.",
+    )
+    parser.add_argument(
+        "--ngram-max",
+        type=int,
+        default=3,
+        help="Maximum character n-gram size.",
+    )
+    parser.add_argument(
+        "--c-value",
+        type=float,
+        default=1.0,
+        help="SVC regularization parameter C.",
+    )
+    return parser
+
+
+def load_records(dataset_path: Path) -> list[TrainableSequenceRecord]:
+    """Load labeled training records from a tab-separated file."""
+    records: list[TrainableSequenceRecord] = []
+    with dataset_path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        required = {"sequence", "label"}
+        if not reader.fieldnames or not required.issubset(set(reader.fieldnames)):
+            raise ValueError("Dataset must include tab-separated columns: sequence,label")
+        for row in reader:
+            sequence = str(row["sequence"]).strip().upper()
+            label = int(str(row["label"]).strip())
+            if label not in (0, 1):
+                raise ValueError(f"Unsupported label value '{label}'; expected 0 or 1.")
+            records.append(
+                TrainableSequenceRecord(
+                    sequence=sequence,
+                    label=SequenceSiteLabel(label),
+                )
+            )
+    if not records:
+        raise ValueError("Dataset is empty.")
+    return records
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Train and persist one splice-site model bundle."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    dataset_path = Path(args.dataset)
+    artifact_path = Path(args.artifact)
+    metadata_path = Path(args.metadata)
+    records = load_records(dataset_path)
+    model = SpliceSiteSvmModel.train(
+        records,
+        site_type=SpliceSiteType(args.site_type),
+        dimer=args.dimer,
+        exon_window=args.exon_window,
+        intron_window=args.intron_window,
+        threshold=args.threshold,
+        ngram_min=args.ngram_min,
+        ngram_max=args.ngram_max,
+        c_value=args.c_value,
+    )
+    model.save(artifact_path=artifact_path, metadata_path=metadata_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/helpers/splice_graph_fixture_builder.py
+++ b/tests/helpers/splice_graph_fixture_builder.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pysam
+
+
+@dataclass(frozen=True)
+class SpliceGraphFixture:
+    """Synthetic fixture paths used by splice-core graph and filtering tests."""
+
+    reference_fasta: Path
+    gtf_path: Path
+    bam_path: Path
+    sam_path: Path
+    chromosome: str
+    gene_id: str
+
+
+def _build_segment(
+    *,
+    name: str,
+    start_0based: int,
+    cigar: tuple[tuple[int, int], ...],
+    query_length: int,
+) -> pysam.AlignedSegment:
+    """Create one aligned segment with deterministic read metadata."""
+    segment = pysam.AlignedSegment()
+    segment.query_name = name
+    segment.query_sequence = "A" * query_length
+    segment.flag = 0
+    segment.reference_id = 0
+    segment.reference_start = start_0based
+    segment.mapping_quality = 60
+    segment.cigar = cigar
+    segment.next_reference_id = -1
+    segment.next_reference_start = -1
+    segment.template_length = 0
+    segment.query_qualities = pysam.qualitystring_to_array("I" * query_length)
+    return segment
+
+
+def build_splice_graph_fixture(tmp_path: Path) -> SpliceGraphFixture:
+    """Build a compact BAM/SAM + GTF fixture with IR/ES/A3 evidence."""
+    chromosome = "chr1"
+    gene_id = "GENE_SYNTH"
+
+    reference_fasta = tmp_path / "reference.fa"
+    reference_fasta.write_text(f">{chromosome}\n" + ("A" * 2000) + "\n", encoding="utf-8")
+    pysam.faidx(str(reference_fasta))
+
+    # Exons:
+    #   E1: 100-149
+    #   E2: 200-249
+    #   E3: 300-349
+    # Transcript T1: E1-E2-E3 (inclusion)
+    # Transcript T2: E1-E3    (exon skipping)
+    gtf_path = tmp_path / "model.gtf"
+    exon_records = [
+        (100, 149, "T1"),
+        (200, 249, "T1"),
+        (300, 349, "T1"),
+        (100, 149, "T2"),
+        (300, 349, "T2"),
+    ]
+    gtf_path.write_text(
+        "\n".join(
+            [
+                (
+                    f'{chromosome}\tsynth\texon\t{start}\t{end}\t.\t+\t.\t'
+                    f'gene_id "{gene_id}"; transcript_id "{transcript_id}";'
+                )
+                for start, end, transcript_id in exon_records
+            ]
+            + [""]
+        ),
+        encoding="utf-8",
+    )
+
+    header = {"HD": {"VN": "1.0"}, "SQ": [{"SN": chromosome, "LN": 2000}]}
+
+    segments = [
+        # Junction E1->E2: 50M50N50M
+        _build_segment(
+            name="jct_e1_e2",
+            start_0based=99,
+            cigar=((0, 50), (3, 50), (0, 50)),
+            query_length=100,
+        ),
+        # Junction E2->E3: 50M50N50M
+        _build_segment(
+            name="jct_e2_e3",
+            start_0based=199,
+            cigar=((0, 50), (3, 50), (0, 50)),
+            query_length=100,
+        ),
+        # Skipping junction E1->E3: 50M150N50M
+        _build_segment(
+            name="jct_e1_e3",
+            start_0based=99,
+            cigar=((0, 50), (3, 150), (0, 50)),
+            query_length=100,
+        ),
+        # Retained intron read spanning E1+I1+E2: 150M
+        _build_segment(
+            name="retained_i1",
+            start_0based=99,
+            cigar=((0, 150),),
+            query_length=150,
+        ),
+    ]
+
+    bam_path = tmp_path / "reads.bam"
+    with pysam.AlignmentFile(bam_path, "wb", header=header) as bam_stream:
+        for segment in segments:
+            bam_stream.write(segment)
+
+    sam_path = tmp_path / "reads.sam"
+    with pysam.AlignmentFile(sam_path, "w", header=header) as sam_stream:
+        for segment in segments:
+            sam_stream.write(segment)
+
+    return SpliceGraphFixture(
+        reference_fasta=reference_fasta,
+        gtf_path=gtf_path,
+        bam_path=bam_path,
+        sam_path=sam_path,
+        chromosome=chromosome,
+        gene_id=gene_id,
+    )

--- a/tests/test_splice_core_filtering.py
+++ b/tests/test_splice_core_filtering.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from iDiffIR.splice_core.filtering import (
+    SequenceSiteLabel,
+    SpliceSiteSvmModel,
+    TrainableSequenceRecord,
+    load_splice_site_model,
+)
+
+
+def _training_records() -> list[TrainableSequenceRecord]:
+    """Build a tiny deterministic labeled dataset for classifier tests."""
+    return [
+        TrainableSequenceRecord(sequence="GTAAAAAA", label=SequenceSiteLabel.POSITIVE),
+        TrainableSequenceRecord(sequence="GTCCCCCC", label=SequenceSiteLabel.POSITIVE),
+        TrainableSequenceRecord(sequence="AGAAAAAA", label=SequenceSiteLabel.NEGATIVE),
+        TrainableSequenceRecord(sequence="AGCCCCCC", label=SequenceSiteLabel.NEGATIVE),
+    ]
+
+
+def test_splice_site_svm_model_trains_predicts_and_roundtrips(tmp_path: Path) -> None:
+    pytest.importorskip("skops.io")
+    records = _training_records()
+    model = SpliceSiteSvmModel.train(records)
+
+    predictions = model.predict_labels([record.sequence for record in records])
+    expected = np.asarray([record.label.value for record in records], dtype=np.int64)
+    accuracy = float((predictions == expected).mean())
+    assert accuracy >= 0.75
+
+    artifact_path = tmp_path / "donor_filter.skops"
+    metadata_path = tmp_path / "donor_filter.metadata.json"
+    model.save(artifact_path=artifact_path, metadata_path=metadata_path)
+    restored = SpliceSiteSvmModel.load(artifact_path=artifact_path, metadata_path=metadata_path)
+    restored_from_spec = load_splice_site_model(metadata_path)
+
+    restored_predictions = restored.predict_labels([record.sequence for record in records])
+    from_spec_predictions = restored_from_spec.predict_labels(
+        [record.sequence for record in records]
+    )
+    assert np.array_equal(predictions, restored_predictions)
+    assert np.array_equal(predictions, from_spec_predictions)
+
+
+def test_training_cli_writes_skops_bundle(tmp_path: Path) -> None:
+    pytest.importorskip("skops.io")
+    dataset_path = tmp_path / "training.tsv"
+    artifact_path = tmp_path / "donor_model.skops"
+    metadata_path = tmp_path / "donor_model.metadata.json"
+    dataset_path.write_text(
+        "\n".join(
+            [
+                "sequence\tlabel",
+                "GTAAAAAA\t1",
+                "GTCCCCCC\t1",
+                "AGAAAAAA\t0",
+                "AGCCCCCC\t0",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/train_splice_site_svm.py",
+            "--dataset",
+            str(dataset_path),
+            "--artifact",
+            str(artifact_path),
+            "--metadata",
+            str(metadata_path),
+            "--site-type",
+            "donor",
+            "--dimer",
+            "GT",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert artifact_path.exists()
+    assert metadata_path.exists()

--- a/tests/test_splice_core_graph.py
+++ b/tests/test_splice_core_graph.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from iDiffIR.splice_core.events import (
+    AlternativeSpliceSiteType,
+    detect_alternative_splice_sites,
+    detect_exon_skipping,
+    detect_intron_retention,
+)
+from iDiffIR.splice_core.graph import build_splice_graph
+from tests.helpers.splice_graph_fixture_builder import build_splice_graph_fixture
+
+
+def test_build_splice_graph_detects_ir_es_and_alt_acceptor_events(tmp_path: Path) -> None:
+    fixture = build_splice_graph_fixture(tmp_path)
+    context = build_splice_graph(
+        annotation_path=fixture.gtf_path,
+        alignment_path=fixture.bam_path,
+    )
+
+    intron_retention_events = detect_intron_retention(context)
+    assert intron_retention_events, "expected at least one intron-retention event"
+    first_ir = intron_retention_events[0]
+    assert first_ir.gene_id == fixture.gene_id
+    assert first_ir.retained_support >= 1
+    assert first_ir.spliced_support >= 1
+    assert first_ir.retained_ratio > 0.0
+
+    exon_skipping_events = detect_exon_skipping(context)
+    assert exon_skipping_events, "expected at least one exon-skipping event"
+    assert any(
+        event.skipped_exon_start == 200 and event.skipped_exon_end == 249
+        for event in exon_skipping_events
+    )
+
+    alt_events = detect_alternative_splice_sites(context)
+    assert alt_events, "expected at least one alternative splice-site event"
+    assert any(event.site_type == AlternativeSpliceSiteType.ALT3 for event in alt_events)
+
+
+def test_build_splice_graph_supports_sam_input(tmp_path: Path) -> None:
+    fixture = build_splice_graph_fixture(tmp_path)
+    context = build_splice_graph(
+        annotation_path=fixture.gtf_path,
+        alignment_path=fixture.sam_path,
+    )
+
+    intron_retention_events = detect_intron_retention(context)
+    assert intron_retention_events
+
+
+def test_build_splice_graph_is_deterministic(tmp_path: Path) -> None:
+    fixture = build_splice_graph_fixture(tmp_path)
+    context_one = build_splice_graph(
+        annotation_path=fixture.gtf_path,
+        alignment_path=fixture.bam_path,
+    )
+    context_two = build_splice_graph(
+        annotation_path=fixture.gtf_path,
+        alignment_path=fixture.bam_path,
+    )
+
+    signature_one = [
+        (
+            event.gene_id,
+            event.intron_start,
+            event.intron_end,
+            event.retained_support,
+            event.spliced_support,
+        )
+        for event in detect_intron_retention(context_one)
+    ]
+    signature_two = [
+        (
+            event.gene_id,
+            event.intron_start,
+            event.intron_end,
+            event.retained_support,
+            event.spliced_support,
+        )
+        for event in detect_intron_retention(context_two)
+    ]
+    assert signature_one == signature_two

--- a/uv.lock
+++ b/uv.lock
@@ -422,11 +422,16 @@ source = { editable = "." }
 dependencies = [
     { name = "gffutils" },
     { name = "matplotlib" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pysam" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "skops" },
 ]
 
 [package.dev-dependencies]
@@ -445,9 +450,12 @@ dev = [
 requires-dist = [
     { name = "gffutils", specifier = ">=0.13" },
     { name = "matplotlib" },
+    { name = "networkx", specifier = ">=3.4.2" },
     { name = "numpy" },
     { name = "pysam" },
+    { name = "scikit-learn", specifier = ">=1.7.2" },
     { name = "scipy" },
+    { name = "skops", specifier = ">=0.13.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -815,6 +823,30 @@ wheels = [
 ]
 
 [[package]]
+name = "networkx"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f", size = 1723263, upload-time = "2024-10-21T12:39:36.247Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1084,6 +1116,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prettytable"
+version = "3.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
 ]
 
 [[package]]
@@ -1530,6 +1574,25 @@ wheels = [
 ]
 
 [[package]]
+name = "skops"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "prettytable" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/0c/5ec987633e077dd0076178ea6ade2d6e57780b34afea0b497fb507d7a1ed/skops-0.13.0.tar.gz", hash = "sha256:66949fd3c95cbb5c80270fbe40293c0fe1e46cb4a921860e42584dd9c20ebeb1", size = 581312, upload-time = "2025-08-06T09:48:14.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/e8/6a2b2030f0689f894432b9c2f0357f2f3286b2a00474827e04b8fe9eea13/skops-0.13.0-py3-none-any.whl", hash = "sha256:55e2cccb18c86f5916e4cfe5acf55ed7b0eecddf08a151906414c092fa5926dc", size = 131200, upload-time = "2025-08-06T09:48:13.356Z" },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1599,6 +1662,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add new `iDiffIR.splice_core` micro-library modules for Python 3-native splice processing:
  - `graph.py`: deterministic NetworkX DAG construction from annotation + SAM/BAM/CRAM alignment support
  - `events.py`: deterministic IR / ES / ALT5 / ALT3 traversal queries
  - `filtering.py`: scikit-learn SVM filtering with `StandardScaler` and secure `skops` persistence
- add new training CLI `scripts/train_splice_site_svm.py` to train modern sequence-site models from tabular datasets
- migrate `iDiffIR/SpliceGrapher/scripts/sam_filter.py` off legacy PyML runtime loading to new `skops` model bundles + extracted sequence-context classification flow
- update packaging/dependencies (`pyproject.toml`, `uv.lock`) for `networkx`, `scikit-learn`, and `skops`
- add synthetic fixture-backed regression tests for graph traversal and filtering round-trips

Closes #60.

## Verification
- `uv run ruff check iDiffIR/splice_core scripts/train_splice_site_svm.py tests/helpers/splice_graph_fixture_builder.py tests/test_splice_core_graph.py tests/test_splice_core_filtering.py`
- `uv run pytest -q tests/test_splice_core_graph.py tests/test_splice_core_filtering.py`
- `uv run pytest -q -m "not performance"`
- `uv run python -W error::SyntaxWarning -m compileall -f -q iDiffIR scripts tests`
- `uv run python iDiffIR/SpliceGrapher/scripts/sam_filter.py --help`
